### PR TITLE
Feature: explicit modifiers

### DIFF
--- a/modules/mixins/style-resolver.js
+++ b/modules/mixins/style-resolver.js
@@ -48,12 +48,16 @@ var StyleResolverMixin = {
     return breakpointStyles;
   },
 
-  _getModifierStyles: function (styles) {
+  _getModifierStyles: function (styles, activeModifiers) {
+    if (!activeModifiers) {
+      return styles.standard;
+    }
+
     var modifierStyles = merge({}, styles.standard);
 
     forEach(styles.modifiers, function (modifier, key) {
-      if (this.props[key]) {
-        var modifierValue = this.props[key];
+      if (activeModifiers[key]) {
+        var modifierValue = activeModifiers[key];
         var activeModifier;
 
         if (typeof modifierValue === 'string') {
@@ -73,13 +77,13 @@ var StyleResolverMixin = {
           activeModifier
         );
       }
-    }, this);
+    });
 
     return modifierStyles;
   },
 
-  _getStaticStyles: function (styles) {
-    var elementStyles = this._getModifierStyles(styles);
+  _getStaticStyles: function (styles, activeModifiers) {
+    var elementStyles = this._getModifierStyles(styles, activeModifiers);
     var mediaQueryStyles = this._getBreakpointStyles(elementStyles);
 
     return merge(
@@ -112,8 +116,16 @@ var StyleResolverMixin = {
     );
   },
 
-  buildStyles: function (styles) {
-    var staticStyles = this._getStaticStyles(styles);
+  buildStyles: function (styles, additionalModifiers, excludeProps) {
+    var modifiers;
+
+    if (excludeProps) {
+      modifiers = additionalModifiers;
+    } else {
+      modifiers = merge({}, this.props, additionalModifiers);
+    }
+
+    var staticStyles = this._getStaticStyles(styles, modifiers);
 
     return this._getComputedStyles(staticStyles);
   }


### PR DESCRIPTION
This allows users to pass in additional modifiers in addition to ones defined as props (or to exclude props entirely and set modifiers themselves).

Handy for people who want to be explicit about their modifiers instead of hanging them directly off of props, or for cases where a modifier should be based on a `state`, or the combination or multiple props, or other similar circumstances.

API-wise, this adds some additional parameters to `this.buildStyles()`:
- `additionalModifiers` is an object of additional modifiers
- `excludeProps` allows you to prevent Radium from checking `props` for modifiers, so that `additionalModifiers` are your only modifiers.

This will also let you override modifiers set on props, if you so desire (for example, if the state of a component changes and a different modifier should be applied).

Some day I will write documentation.

This branch is off of the computed inline PR I just opened. For a proper diff see https://github.com/FormidableLabs/radium/compare/feature-inlineComputedStyles...feature-explicitModifiers

/cc @colinmegill @aykayen @rgerstenberger 
