### PR TITLE
Style component

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -2,6 +2,7 @@ var React = require('react');
 
 var Button = require('./components/button.jsx');
 var ComputedWell = require("./components/computed-well.jsx");
+var Style = require("../modules/components/style.jsx");
 
 var App = React.createClass({
   render: function () {
@@ -25,6 +26,13 @@ var App = React.createClass({
             Button
           </Button>
         </p>
+
+        <Style>{{
+          body: {
+            margin: 0,
+            fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif"
+          }
+        }}</Style>
 
         <p>
           <ComputedWell>Click me!</ComputedWell>

--- a/modules/components/style.js
+++ b/modules/components/style.js
@@ -1,0 +1,45 @@
+var React = require('react');
+var hyphenateStyleName = require('react/lib/hyphenateStyleName');
+var forEach = require('lodash.foreach');
+var reduce = require('lodash.reduce');
+
+function buildCssString (selector, rules) {
+  // TODO: Better error checking for rules object
+  if (!selector || !rules) {
+    return;
+  }
+
+  var cssString = selector + "{";
+
+  // Turn rules into css properties
+  cssString += reduce(rules, function (s, val, styleName) {
+    return s + hyphenateStyleName(styleName) + ":" + val + ";"
+  }, "");
+
+  // Close selector
+  cssString += "}";
+
+  return cssString;
+}
+
+var Style = React.createClass({
+  render: function () {
+    if (!this.props.selector) {
+      throw new Error("Style tag requires a 'selector' property");
+    }
+
+    // Build styles from standard
+    var styles = buildCssString(this.props.selector, this.props.standard)
+
+    forEach(this.props.states, function (rules, state) {
+      styles += buildCssString(ownerSelector + ":" + state, rules);
+    });
+
+    return (
+      <style dangerouslySetInnerHTML={{__html: styles}}>
+      </style>
+    );
+  }
+});
+
+module.exports = Style;

--- a/modules/components/style.js
+++ b/modules/components/style.js
@@ -24,14 +24,18 @@ function buildCssString (selector, rules) {
 
 var Style = React.createClass({
   render: function () {
-    if (!this.props.selector) {
-      throw new Error("Style tag requires a 'selector' property");
+    if (!this.props.selector || typeof this.props.selector !== "string") {
+      throw new Error("Style tag requires a 'selector' string");
+    }
+
+    if (!this.props.styles || typeof this.props.styles !== "object") {
+      throw new Error("Style tag requires a 'styles' object");
     }
 
     // Build styles from standard
-    var styles = buildCssString(this.props.selector, this.props.standard)
+    var styles = buildCssString(this.props.selector, this.props.styles.standard)
 
-    forEach(this.props.states, function (rules, state) {
+    forEach(this.props.styles.states, function (rules, state) {
       styles += buildCssString(ownerSelector + ":" + state, rules);
     });
 

--- a/modules/components/style.jsx
+++ b/modules/components/style.jsx
@@ -24,25 +24,24 @@ function buildCssString (selector, rules) {
 
 var Style = React.createClass({
   render: function () {
-    if (!this.props.selector || typeof this.props.selector !== "string") {
-      throw new Error("Style tag requires a 'selector' string");
+    var styles;
+
+    // Throw error if someone passes in valid children that isn't an object
+    if (this.props.children && typeof this.props.children !== "object") {
+      throw new Error("Style tag requires an object for 'props.children'");
     }
 
-    if (!this.props.styles || typeof this.props.styles !== "object") {
-      throw new Error("Style tag requires a 'styles' object");
-    }
-
-    // Build styles from standard
-    var styles = buildCssString(this.props.selector, this.props.styles.standard)
-
-    forEach(this.props.styles.states, function (rules, state) {
-      styles += buildCssString(ownerSelector + ":" + state, rules);
+    forEach(this.props.children, function (rules, selector) {
+      styles = buildCssString(selector, rules);
     });
 
-    return (
-      <style dangerouslySetInnerHTML={{__html: styles}}>
-      </style>
-    );
+    if (styles) {
+      return (
+        <style dangerouslySetInnerHTML={{__html: styles}} />
+      );
+    } else {
+      return false;
+    }
   }
 });
 

--- a/modules/components/style.jsx
+++ b/modules/components/style.jsx
@@ -1,6 +1,5 @@
 var React = require('react');
 var hyphenateStyleName = require('react/lib/hyphenateStyleName');
-var forEach = require('lodash.foreach');
 var reduce = require('lodash.reduce');
 
 function buildCssString (selector, rules) {
@@ -24,23 +23,21 @@ function buildCssString (selector, rules) {
 
 var Style = React.createClass({
   render: function () {
-    var styles;
-
     // Throw error if someone passes in valid children that isn't an object
     if (this.props.children && typeof this.props.children !== "object") {
       throw new Error("Style tag requires an object for 'props.children'");
     }
 
-    forEach(this.props.children, function (rules, selector) {
-      styles = buildCssString(selector, rules);
-    });
+    var styles = reduce(this.props.children, function (s, rules, selector) {
+      return s += buildCssString(selector, rules);
+    }, "");
 
     if (styles) {
       return (
         <style dangerouslySetInnerHTML={{__html: styles}} />
       );
     } else {
-      return false;
+      return null;
     }
   }
 });

--- a/modules/components/style.jsx
+++ b/modules/components/style.jsx
@@ -8,17 +8,9 @@ function buildCssString (selector, rules) {
     return;
   }
 
-  var cssString = selector + "{";
-
-  // Turn rules into css properties
-  cssString += reduce(rules, function (s, val, styleName) {
-    return s + hyphenateStyleName(styleName) + ":" + val + ";"
-  }, "");
-
-  // Close selector
-  cssString += "}";
-
-  return cssString;
+  return selector + "{" + Object.keys(rules).map(function (key) {
+    return hyphenateStyleName(key) + ":" + rules[key] + ";";
+  }).join("") + "}";
 }
 
 var Style = React.createClass({


### PR DESCRIPTION
This adds a style component that can be used with the following syntax:

`<Style selector="h2" styles={myStyles} />`

This component is very slow. Considering the main use case is for user generated content, I suggest we attempt to speed it up. Possibly with something like `insertRule` http://davidwalsh.name/add-rules-stylesheets. Really, all uses of this component should update a global stylesheet.

Also, I'm not happy with the API. If the main use case is unknown html on the page then there's probably more than a few selectors needed. I considered taking in an object like: 
```
{
 ".myClass": { background: "#fff"},
 ".otherClass: { background: "#000"}
}
```

But that logic could be very slow and the objects being passed in will be hard to validate. It's also might confuse the other radium style objects, so I opted to keep them similar. 

Lastly, we should probably be reusing the existing logic for building styles so that someone could pass in your average radium style object. 

This PR is not ready for primetime but I wanted to submit it to get clarity on which direction to pursue.

/cc @alexlande, @aykayen, @colinmegill 