### PR TITLE
Chore: Clean up lodash usage

### DIFF
--- a/modules/mixins/style-resolver.js
+++ b/modules/mixins/style-resolver.js
@@ -31,9 +31,7 @@ var StyleResolverMixin = {
       componentMediaQueries = this.state.mediaQueries;
     }
 
-    // Use Object.keys + forEach instead of for...in because media queries
-    // should be iterated over in the order that the user declares them.
-    Object.keys(styles.mediaQueries).forEach(function (key) {
+    for (var key in styles.mediaQueries) {
       var mediaQuery = styles.mediaQueries[key];
 
       if (componentMediaQueries && componentMediaQueries[key]) {
@@ -48,7 +46,7 @@ var StyleResolverMixin = {
           activeMediaQuery
         );
       }
-    });
+    }
 
     mediaQueryStyles.mediaQueries = null;
 
@@ -62,9 +60,7 @@ var StyleResolverMixin = {
 
     var modifierStyles = merge({}, styles);
 
-    // Use Object.keys + forEach instead of for...in because modifiers should
-    // be iterated over in the order that the user declares them.
-    Object.keys(styles.modifiers).forEach(function (key) {
+    for (var key in styles.modifiers) {
       var modifier = styles.modifiers[key];
 
       if (activeModifiers[key]) {
@@ -88,7 +84,7 @@ var StyleResolverMixin = {
           activeModifier
         );
       }
-    });
+    }
 
     return modifierStyles;
   },

--- a/modules/stores/match-media.js
+++ b/modules/stores/match-media.js
@@ -1,6 +1,5 @@
 var EventEmitter = require('events').EventEmitter;
-var merge = require('lodash.merge');
-var forEach = require('lodash.foreach');
+var merge = require('lodash/object/merge');
 
 var CHANGE_EVENT = 'change';
 
@@ -12,21 +11,28 @@ var handleMediaChange = function () {
 
 var MatchMediaStore = merge({}, EventEmitter.prototype, {
   init: function (mediaQueryOpts) {
+    if (!mediaQueryOpts) {
+      return;
+    }
+
     this.destroy();
 
     matchers = {};
 
-    forEach(mediaQueryOpts, function (query, key) {
-      matchers[key] = window.matchMedia(query);
-
+    for (var key in mediaQueryOpts) {
+      matchers[key] = window.matchMedia(mediaQueryOpts[key]);
       matchers[key].addListener(handleMediaChange);
-    });
+    }
   },
 
   destroy: function () {
-    forEach(matchers, function (matcher) {
-      matcher.removeListener(handleMediaChange);
-    });
+    if (!matchers) {
+      return;
+    }
+
+    for (var key in matchers) {
+      matchers[key].removeListener(handleMediaChange);
+    }
   },
 
   _emitChange: function () {
@@ -42,11 +48,15 @@ var MatchMediaStore = merge({}, EventEmitter.prototype, {
   },
 
   getMatchedMedia: function () {
+    if (!matchers) {
+      return;
+    }
+
     var matchedQueries = {};
 
-    forEach(matchers, function (query, key) {
-      matchedQueries[key] = query.matches;
-    });
+    for (var key in matchers) {
+      matchedQueries[key] = matchers[key].matches;
+    }
 
     return matchedQueries;
   }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "react": "0.12.x"
   },
   "dependencies": {
-    "lodash.foreach": "^3.0.1",
-    "lodash.merge": "^3.0.1"
+    "lodash": "^3.2.0"
   },
   "devDependencies": {
     "jsx-loader": "^0.12.2",


### PR DESCRIPTION
This replaces our individual lodash packages with the normal `lodash` package, which supports requiring deep linked individual methods, which is very cool. Thanks @ryan-roemer for pointing that out.

Also replaced some instances of `forEach` with `for...in` loops where appropriate.

Resolves #30 and #31

/cc @ryan-roemer @eastridge @rgerstenberger @colinmegill 