### PR TITLE
Bug: Fix broken computed well example

### DIFF
--- a/examples/components/computed-well.jsx
+++ b/examples/components/computed-well.jsx
@@ -7,7 +7,7 @@ var ComputedWell = React.createClass({
 
   getInitialState: function () {
     return {
-      dynamicBg: null
+      dynamicBg: '#000'
     }
   },
 
@@ -15,16 +15,8 @@ var ComputedWell = React.createClass({
     return {
       padding: "1em",
       borderRadius: 5,
-      background: "#000"
+      background: this.state.dynamicBg
     };
-  },
-
-  buildComputedStyles: function (baseStyles) {
-    var computedStyles = {};
-
-    computedStyles.backgroundColor = this.state.dynamicBg;
-
-    return computedStyles;
   },
 
   handleSubmit: function (ev) {
@@ -36,7 +28,7 @@ var ComputedWell = React.createClass({
   },
 
   render: function () {
-    var styles = this.buildStyles(this.getStyles(), this.buildComputedStyles);
+    var styles = this.buildStyles(this.getStyles());
 
     return (
       <form style={styles} onSubmit={this.handleSubmit}>


### PR DESCRIPTION
The computed well example was using the old computed styles syntax, which isn't supported anymore. It's also a bad example of computed styles in general. Will put some effort into the examples one of these days.

Fixes #51.