### PR TITLE
Chore: Rename and document browser state event handlers

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -148,6 +148,38 @@ Returns a hash of browser state events handlers to set component state when the 
 
 Apply to the component with a spread operator (`{...}`).
 
+**Note**: `getBrowserStateEvents` uses the following React event listeners:
+
+- `onMouseEnter`
+- `onMouseLeave`
+- `onMouseDown`
+- `onMouseUp`
+- `onFocus`
+- `onBlur`
+
+If you need to use Radium to style browser states but also need to add your own event listeners matching any of the 6 previously listed, simply call the corresponding Radium event handler in your own event handler:
+
+React | Radium
+------|-------
+`onMouseEnter` | `radiumMouseEnter`
+`onMouseLeave` | `radiumMouseLeave`
+`onMouseDown` | `radiumMouseDown`
+`onMouseUp` | `radiumMouseUp`
+`onFocus` | `radiumFocus`
+`onBlur` | `radiumBlur`
+
+Example:
+
+```js
+handleFocus: function () {
+  this.radiumFocus();
+
+  // Your custom event behavior.
+}
+```
+
+Event listeners passed in as props from another component are handled automatically.
+
 #### Signature
 
 `getBrowserStateEvents()`

--- a/modules/mixins/browser-state.js
+++ b/modules/mixins/browser-state.js
@@ -9,12 +9,12 @@ var BrowserStateMixin = {
 
   getBrowserStateEvents: function () {
     return {
-      onMouseEnter: this._handleMouseEnter,
-      onMouseLeave: this._handleMouseLeave,
-      onMouseDown: this._handleMouseDown,
-      onMouseUp: this._handleMouseUp,
-      onFocus: this._handleFocus,
-      onBlur: this._handleBlur
+      onMouseEnter: this.radiumMouseEnter,
+      onMouseLeave: this.radiumMouseLeave,
+      onMouseDown: this.radiumMouseDown,
+      onMouseUp: this.radiumMouseUp,
+      onFocus: this.radiumFocus,
+      onBlur: this.radiumBlur
     };
   },
 
@@ -26,7 +26,7 @@ var BrowserStateMixin = {
     }
   },
 
-  _handleMouseEnter: function (ev) {
+  radiumMouseEnter: function (ev) {
     this._callRadiumHandler("onMouseEnter", ev);
 
     this.setState({
@@ -34,7 +34,7 @@ var BrowserStateMixin = {
     });
   },
 
-  _handleMouseLeave: function (ev) {
+  radiumMouseLeave: function (ev) {
     this._callRadiumHandler("onMouseLeave", ev);
 
     this.setState({
@@ -43,7 +43,7 @@ var BrowserStateMixin = {
     });
   },
 
-  _handleMouseDown: function (ev) {
+  radiumMouseDown: function (ev) {
     this._callRadiumHandler("onMouseDown", ev);
 
     this.setState({
@@ -51,7 +51,7 @@ var BrowserStateMixin = {
     });
   },
 
-  _handleMouseUp: function (ev) {
+  radiumMouseUp: function (ev) {
     this._callRadiumHandler("onMouseUp", ev);
 
     this.setState({
@@ -59,7 +59,7 @@ var BrowserStateMixin = {
     });
   },
 
-  _handleFocus: function (ev) {
+  radiumFocus: function (ev) {
     this._callRadiumHandler("onFocus", ev);
 
     this.setState({
@@ -67,7 +67,7 @@ var BrowserStateMixin = {
     });
   },
 
-  _handleBlur: function (ev) {
+  radiumBlur: function (ev) {
     this._callRadiumHandler("onBlur", ev);
 
     this.setState({


### PR DESCRIPTION
This documents a workaround when you need to use Radium browser state event handlers in a component but also need to use your own handlers for the same event at the component level.

Resolves #76 

/cc @colinmegill @eastridge 