### PR TITLE
Remove redundant condition.

### DIFF
--- a/modules/mixins/util/mouse-up-listener.js
+++ b/modules/mixins/util/mouse-up-listener.js
@@ -12,7 +12,7 @@ var subscribe = function (callback) {
     _callbacks.push(callback);
   }
 
-  if (_callbacks.length > 0 && !_mouseUpListenerIsActive) {
+  if (!_mouseUpListenerIsActive) {
     window.addEventListener("mouseup", _handleMouseUp);
     _mouseUpListenerIsActive = true;
   }


### PR DESCRIPTION
The length of `_callbacks` is always greater than 0 at this point in the code.