### PR TITLE
Bug: Modify matchedQueries, don't return a new one

### DIFF
--- a/modules/mixins/match-media-base.js
+++ b/modules/mixins/match-media-base.js
@@ -2,6 +2,7 @@ var React = require('react');
 var debounce = require('lodash/function/debounce');
 
 var matchers = {};
+var matchedQueries = {};
 
 var mediaChangeCallback;
 
@@ -48,20 +49,14 @@ var MatchMediaBase = {
   },
 
   getMatchedMedia: function () {
-    if (!matchers) {
-      return;
-    }
-
-    var matchedQueries = {};
-
-    for (var key in matchers) {
-      matchedQueries[key] = matchers[key].matches;
-    }
-
     return matchedQueries;
   },
 
   handleMediaChange: debounce(function () {
+    for (var key in matchers) {
+      matchedQueries[key] = matchers[key].matches;
+    }
+
     this.forceUpdate();
   }, 10, {
     maxWait: 250


### PR DESCRIPTION
This fixes an issue that the new context error messages in React 0.13 made clear: that we were returning a new `matchedQueries` object for every child component rendered.