### PR TITLE
Feature: linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,229 @@
+ecmaFeatures:
+    jsx: true
+
+env:
+    browser: true
+    node: true
+    amd: false
+    mocha: false
+    jasmine: false
+
+globals:
+    require: true
+    module: true
+
+rules:
+
+    ###########################################################################
+    #                                                                         #
+    #   POSSIBLE ERRORS: these rules point out areas where you might have     #
+    #   made mistakes.                                                        #
+    #                                                                         #
+    ###########################################################################
+
+    no-comma-dangle: 2         # disallow trailing commas in object literals
+    no-cond-assign: 2          # disallow assignment in conditional expressions
+    no-console: 2              # disallow use of console
+    no-constant-condition: 2   # disallow use of constant expressions in conditions
+    no-control-regex: 2        # disallow control characters in regular expressions
+    no-debugger: 2             # disallow use of debugger
+    no-dupe-keys: 2            # disallow duplicate keys when creating object literals
+    no-empty: 2                # disallow empty statements
+    no-empty-class: 2          # disallow the use of empty character classes in regular expressions
+    no-ex-assign: 2            # disallow assigning to the exception in a catch block
+    no-extra-boolean-cast: 2   # disallow double-negation boolean casts in a boolean context
+    no-extra-parens: 0         # disallow unnecessary parentheses
+                               # NOTE: Allow for `return (/* JSX STUFF*/);` situations
+    no-extra-semi: 2           # disallow unnecessary semicolons
+    no-func-assign: 2          # disallow overwriting functions written as function declarations
+    no-inner-declarations: 1   # disallow function or variable declarations in nested blocks
+    no-invalid-regexp: 2       # disallow invalid regular expression strings in the RegExp
+                               #    constructor
+    no-irregular-whitespace: 2 # disallow irregular whitespace outside of strings and comments
+    no-negated-in-lhs: 2       # disallow negation of the left operand of an in expression
+    no-obj-calls: 2            # disallow the use of object properties of the global object (Math
+                               #    and JSON) as functions
+    no-regex-spaces: 1         # disallow multiple spaces in a regular expression literal
+    no-reserved-keys: 1        # disallow reserved words being used as object literal keys
+    no-sparse-arrays: 2        # disallow sparse arrays
+    no-unreachable: 2          # disallow unreachable statements after a return, throw, continue,
+                               #    or break statement
+    use-isnan: 2               # disallow comparisons with the value NaN
+    valid-typeof: 2            # ensure that the results of typeof are compared against a
+                               #    valid string
+
+    valid-jsdoc:               # ensure JSDoc comments are valid
+        [1, { "prefer": { "return": "returns" }, "requireReturn": false }]
+
+    ###########################################################################
+    #                                                                         #
+    #   BEST PRACTICES: these rules are designed to prevent you from making   #
+    #   mistakes. They either prescribe a better way of doing something or    #
+    #   help you avoid pitfalls.                                              #
+    #                                                                         #
+    ###########################################################################
+
+    block-scoped-var: 1       # treat var statements as if they were block scoped
+    complexity: [1, 250]      # specify the maximum cyclomatic complexity allowed in a program
+    consistent-return: 0      # require return statements to either always or never specify values
+    curly: 2                  # specify curly brace conventions for all control statements
+    default-case: 2           # require default case in switch statements
+    dot-notation: 1           # encourages use of dot notation whenever possible
+    eqeqeq: 2                 # require the use of === and !==
+    guard-for-in: 1           # make sure for-in loops have an if statement
+    no-alert: 2               # disallow the use of alert, confirm, and prompt
+    no-caller: 2              # disallow use of arguments.caller or arguments.callee
+    no-div-regex: 1           # disallow division operators explicitly at beginning of regular
+                              #    expression
+    no-else-return: 1         # disallow else after a return in an if
+    no-empty-label: 2         # disallow use of labels for anything other then loops and switches
+    no-eq-null: 2             # disallow comparisons to null without a type-checking operator
+    no-eval: 2                # disallow use of eval()
+    no-extend-native: 2       # disallow adding to native types
+    no-extra-bind: 2          # disallow unnecessary function binding
+    no-fallthrough: 2         # disallow fallthrough of case statements
+    no-floating-decimal: 2    # disallow the use of leading or trailing decimal points in numeric
+                              #    literals
+    no-implied-eval: 2        # disallow use of eval()-like methods
+    no-iterator: 2            # disallow usage of __iterator__ property
+    no-labels: 2              # disallow use of labeled statements
+    no-lone-blocks: 2         # disallow unnecessary nested blocks
+    no-loop-func: 0           # disallow creation of functions within loops
+    no-multi-spaces: 0        # disallow use of multiple spaces
+    no-multi-str: 2           # disallow use of multiline strings
+    no-native-reassign: 2     # disallow reassignments of native objects
+    no-new: 2                 # disallow use of new operator when not part of the assignment or
+                              #    comparison
+    no-new-func: 2            # disallow use of new operator for Function object
+    no-new-wrappers: 2        # disallows creating new instances of String,Number, and Boolean
+    no-octal: 2               # disallow use of octal literals
+    no-octal-escape: 2        # disallow use of octal escape sequences in string literals, such as
+                              #    `var foo = "Copyright \251"`
+    no-process-env: 0         # disallow use of process.env
+    no-proto: 2               # disallow usage of __proto__ property
+    no-redeclare: 1           # disallow declaring the same variable more then once
+    no-return-assign: 0       # disallow use of assignment in return statement
+    no-script-url: 2          # disallow use of javascript urls.
+    no-self-compare: 2        # disallow comparisons where both sides are exactly the same
+    no-sequences: 2           # disallow use of comma operator
+    no-unused-expressions: 0  # disallow usage of expressions in statement position
+    no-void: 2                # disallow use of void operator
+    no-warning-comments: 0    # disallow usage of configurable warning terms in comments - e.g.
+                              #     TODO or FIXME
+    no-with: 2                # disallow use of the with statement
+    radix: 2                  # require use of the second argument for parseInt()
+    vars-on-top: 0            # requires to declare all vars on top of their containing scope
+    wrap-iife: [2, "inside"]  # require immediate function invocation to be wrapped in parentheses
+    yoda: "never"             # require or disallow Yoda conditions
+
+    ###########################################################################
+    #                                                                         #
+    #   STRICT MODE: these rules relate to using strict mode.                 #
+    #                                                                         #
+    ###########################################################################
+
+    global-strict: [2, "never"] # require or disallow the "use strict" pragma in the global scope
+    no-extra-strict: 2          # disallow use of "use strict" when already in strict mode
+    strict: 0                   # require that all functions are run in strict mode
+
+    ###########################################################################
+    #                                                                         #
+    #   VARIABLES: these rules have to do with variable declarations.         #
+    #                                                                         #
+    ###########################################################################
+
+    no-catch-shadow: 2             # disallow the catch clause parameter name being the same as a
+                                   #    variable in the outer scope
+    no-delete-var: 2               # disallow deletion of variables
+    no-label-var: 2                # disallow labels that share a name with a variable
+    no-shadow: 1                   # disallow declaration of variables already declared in the
+                                   #    outer scope
+    no-shadow-restricted-names: 2  # disallow shadowing of names such as arguments
+    no-undef: 2                    # disallow use of undeclared variables unless mentioned in a
+                                   #    /*global */ block
+    no-undef-init: 2               # disallow use of undefined when initializing variables
+    no-undefined: 2                # disallow use of undefined variable
+    no-unused-vars: 2              # disallow declaration of variables that are not used in
+                                   #    the code
+    no-use-before-define: 2        # disallow use of variables before they are defined
+
+    ###########################################################################
+    #                                                                         #
+    #   NODE: these rules relate to functionality provided in Node.js.        #
+    #                                                                         #
+    ###########################################################################
+
+    handle-callback-err: 0        # enforces error handling in callbacks
+    no-mixed-requires: [1, true]  # disallow mixing regular variable and require declarations
+    no-new-require: 2             # disallow use of new operator with the require function
+    no-path-concat: 2             # disallow string concatenation with __dirname and __filename
+    no-process-exit: 0            # disallow process.exit()
+    no-restricted-modules: 0      # restrict usage of specified node modules
+    no-sync: 0                    # disallow use of synchronous methods
+
+    ###########################################################################
+    #                                                                         #
+    #   STYLISTIC ISSUES: these rules are purely matters of style and,        #
+    #   while valueable to enforce consistently across a project, are         #
+    #   quite subjective.                                                     #
+    #                                                                         #
+    ###########################################################################
+
+    brace-style:                   # enforce one true brace style
+        [2, "1tbs", { "allowSingleLine": true }]
+    camelcase: 2                   # require camel case names
+    comma-spacing: 2               # enforce spacing before and after comma
+    comma-style: 2                 # enforce one true comma style
+    consistent-this: [2, "self"]   # enforces consistent naming when capturing the current execution context
+    eol-last: 2                    # enforce newline at the end of file, with no multiple empty lines
+    func-names: 0                  # require function expressions to have a name
+    func-style: 0                  # enforces use of function declarations or expressions
+    key-spacing: 2                 # enforces spacing between keys and values in object literal properties
+    max-nested-callbacks: [2, 4]   # specify the maximum depth callbacks can be nested
+    new-cap: 2                     # require a capital letter for constructors
+    new-parens: 2                  # disallow the omission of parentheses when invoking a constructor with no arguments
+    no-array-constructor: 2        # disallow use of the Array constructor
+    no-lonely-if: 0                # disallow if as the only statement in an else block
+    no-mixed-spaces-and-tabs: 2    # disallow mixed spaces and tabs for indentation
+    no-nested-ternary: 2           # disallow nested ternary expressions
+    no-new-object: 1               # disallow use of the Object constructor
+    no-space-before-semi: 2        # disallow space before semicolon
+    no-spaced-func: 2              # disallow space between function identifier and application
+    no-ternary: 0                  # disallow the use of ternary operators
+
+    no-trailing-spaces: 2          # disallow trailing whitespace at the end of lines
+    no-multiple-empty-lines: 2     # disallow multiple empty lines
+    no-underscore-dangle: 0        # disallow dangling underscores in identifiers
+    no-wrap-func: 2                # disallow wrapping of non-IIFE statements in parens
+    one-var: 0                     # allow just one var statement per function
+    padded-blocks: 0               # enforce padding within blocks
+    quotes:                        # specify whether double or single quotes should be used
+        [1, "single", "avoid-escape"]
+    quote-props: 0                 # require quotes around object literal property names
+    semi: [2, "always"]            # require or disallow use of semicolons instead of ASI
+    sort-vars: 0                   # sort variables within the same declaration block
+    space-after-keywords: "always" # require a space after certain keywords
+    space-before-blocks: 2         # require or disallow space before blocks
+    space-in-brackets: 0           # require or disallow spaces inside brackets
+    space-in-parens: 0             # require or disallow spaces inside parentheses
+    space-infix-ops: 2             # require spaces around operators
+    space-return-throw-case: 2     # require a space after return, throw, and case
+    spaced-line-comment: 2         # require or disallow a space immediately following
+                                   #    the // in a line comment
+    wrap-regex: 0                  # require regex literals to be wrapped in parentheses
+
+    ###########################################################################
+    #                                                                         #
+    #   LEGACY: these rules are included for compatibility with JSHint and    #
+    #   JSLint.  While the names of the rules may not match up with their     #
+    #   JSHint/JSLint counterpart, the functionality is the same.             #
+    #                                                                         #
+    ###########################################################################
+
+    max-depth: 0              # specify the maximum depth that blocks can be nested
+    max-len: [2, 100, 4]      # specify the maximum length of a line in your program
+    max-params: [1, 3]        # limits the number of parameters that can be used in the function
+                              #    declaration
+    max-statements: 0         # specify the maximum number of statement allowed in a function
+    no-bitwise: 0             # disallow use of bitwise operators
+    no-plusplus: 0            # disallow use of unary operators, ++ and --

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Thanks for contributing!
+
+## Development
+
+Run `npm run examples` to run a webpack dev server with Radium examples.
+
+## Lint
+
+Run `gulp check` before committing to lint files.
+
+## Dist
+
+Please do not commit changes to files in `dist`. These files are only committed when we tag releases.

--- a/README.md
+++ b/README.md
@@ -102,3 +102,7 @@ To see local examples in action, do this:
 npm install
 npm run examples
 ```
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,3 +7,5 @@ gulp.task('eslint', function () {
     .pipe(eslint.formatEach('stylish', process.stderr))
     .pipe(eslint.failOnError());
 });
+
+gulp.task('check', ['eslint']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ gulp.task('eslint', function () {
   gulp.src('./modules/**/*.js')
     .pipe(eslint())
     .pipe(eslint.formatEach('stylish', process.stderr))
-    .pipe(eslint.failOnError());
+    .pipe(eslint.failAfterError());
 });
 
 gulp.task('check', ['eslint']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,9 @@
+var gulp = require('gulp');
+var eslint = require('gulp-eslint');
+
+gulp.task('eslint', function () {
+  gulp.src('./modules/**/*.js')
+    .pipe(eslint())
+    .pipe(eslint.formatEach('stylish', process.stderr))
+    .pipe(eslint.failOnError());
+});

--- a/modules/components/style.js
+++ b/modules/components/style.js
@@ -7,9 +7,9 @@ function buildCssString (selector, rules) {
     return;
   }
 
-  return selector + "{" +
+  return selector + '{' +
     CSSPropertyOperations.createMarkupForStyles(rules) +
-  "}";
+  '}';
 }
 
 var Style = React.createClass({
@@ -20,8 +20,8 @@ var Style = React.createClass({
 
   getDefaultProps: function () {
     return {
-      scopeSelector: ""
-    }
+      scopeSelector: ''
+    };
   },
 
   render: function () {
@@ -32,13 +32,13 @@ var Style = React.createClass({
     var styles = reduce(this.props.rules, function (s, item) {
       var selector = Object.keys(item)[0];
       var rules = item[selector];
-      var completeSelector = this.props.scopeSelector + " " + selector;
+      var completeSelector = this.props.scopeSelector + ' ' + selector;
 
       return s += buildCssString(completeSelector, rules);
-    }, "", this);
+    }, '', this);
 
     return React.createElement(
-      "style",
+      'style',
       {dangerouslySetInnerHTML: {__html: styles}}
     );
   }

--- a/modules/mixins/browser-state.js
+++ b/modules/mixins/browser-state.js
@@ -1,4 +1,4 @@
-var mouseUpListener = require("./util/mouse-up-listener");
+var mouseUpListener = require('./util/mouse-up-listener');
 
 var BrowserStateMixin = {
 
@@ -37,7 +37,7 @@ var BrowserStateMixin = {
   },
 
   radiumMouseEnter: function (ev) {
-    this._callRadiumHandler("onMouseEnter", ev);
+    this._callRadiumHandler('onMouseEnter', ev);
 
     this.setState({
       hover: true
@@ -45,7 +45,7 @@ var BrowserStateMixin = {
   },
 
   radiumMouseLeave: function (ev) {
-    this._callRadiumHandler("onMouseLeave", ev);
+    this._callRadiumHandler('onMouseLeave', ev);
 
     this.setState({
       hover: false
@@ -53,14 +53,14 @@ var BrowserStateMixin = {
   },
 
   radiumMouseDown: function (ev) {
-    this._callRadiumHandler("onMouseDown", ev);
+    this._callRadiumHandler('onMouseDown', ev);
 
     this.setState({
       active: true
     });
   },
 
-  radiumMouseUp: function (ev) {
+  radiumMouseUp: function () {
     if (this.state.active) {
       this.setState({
         active: false
@@ -69,7 +69,7 @@ var BrowserStateMixin = {
   },
 
   radiumFocus: function (ev) {
-    this._callRadiumHandler("onFocus", ev);
+    this._callRadiumHandler('onFocus', ev);
 
     this.setState({
       focus: true
@@ -77,7 +77,7 @@ var BrowserStateMixin = {
   },
 
   radiumBlur: function (ev) {
-    this._callRadiumHandler("onBlur", ev);
+    this._callRadiumHandler('onBlur', ev);
 
     this.setState({
       focus: false

--- a/modules/mixins/match-media-base.js
+++ b/modules/mixins/match-media-base.js
@@ -22,14 +22,14 @@ var MatchMediaBase = {
   },
 
   init: function (mediaQueryOpts) {
-    if (!mediaQueryOpts || typeof window === "undefined") {
+    if (!mediaQueryOpts || typeof window === 'undefined') {
       return;
     }
 
-    for (var key in mediaQueryOpts) {
+    Object.keys(mediaQueryOpts).forEach(function (key) {
       matchers[key] = window.matchMedia(mediaQueryOpts[key]);
       matchers[key].addListener(onMediaChange);
-    }
+    });
   },
 
   componentWillMount: function () {
@@ -43,9 +43,9 @@ var MatchMediaBase = {
       return;
     }
 
-    for (var key in matchers) {
-      matchers[key].removeListener(handleMediaChange);
-    }
+    Object.keys(matchers).forEach(function (key) {
+      matchers[key].removeListener(onMediaChange);
+    });
   },
 
   getMatchedMedia: function () {
@@ -53,9 +53,9 @@ var MatchMediaBase = {
   },
 
   handleMediaChange: debounce(function () {
-    for (var key in matchers) {
+    Object.keys(matchers).forEach(function (key) {
       matchedQueries[key] = matchers[key].matches;
-    }
+    });
 
     this.forceUpdate();
   }, 10, {

--- a/modules/mixins/style-resolver.js
+++ b/modules/mixins/style-resolver.js
@@ -111,9 +111,9 @@ var StyleResolverMixin = {
       computedStyles = styles.computed(styles);
     // or it can be an object of functions mapping to individual rules.
     } else {
-      for (var key in styles.computed) {
+      Object.keys(styles.computed).forEach(function (key) {
         computedStyles[key] = styles.computed[key](styles);
-      }
+      });
     }
 
     return merge(

--- a/modules/mixins/util/mouse-up-listener.js
+++ b/modules/mixins/util/mouse-up-listener.js
@@ -13,7 +13,7 @@ var subscribe = function (callback) {
   }
 
   if (!_mouseUpListenerIsActive) {
-    window.addEventListener("mouseup", _handleMouseUp);
+    window.addEventListener('mouseup', _handleMouseUp);
     _mouseUpListenerIsActive = true;
   }
 
@@ -23,11 +23,11 @@ var subscribe = function (callback) {
       _callbacks.splice(index, 1);
 
       if (_callbacks.length === 0 && _mouseUpListenerIsActive) {
-        window.removeEventListener("mouseup", _handleMouseUp);
+        window.removeEventListener('mouseup', _handleMouseUp);
         _mouseUpListenerIsActive = false;
       }
     }
-  }
+  };
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "lodash": "^3.2.0"
   },
   "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-eslint": "^0.6.0",
     "jsx-loader": "^0.12.2",
     "react": "0.12.x",
     "webpack": "^1.5.3",


### PR DESCRIPTION
This adds

- ESlint
- A gulpfile to run ESlint (and other checks once they're added)
- CONTRIBUTING.md
- Cleans up all of our existing lint

@ryan-roemer is going to kill me for this, but I didn't add JSCS. It just felt like overkill beyond the pretty good style conformance checks in our `.eslintrc` (which I stole from @ryan-roemer and modified very slightly). If we want even more strict code style later we can add it in.

I also changed some `for...in` loops to `Object.keys().forEach` because I meant to do that a long time ago and ESlint complained about it because of the whole `hasOwnProperty` thing.

Resolves #74.