### PR TITLE
Add media query API to `Style`

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -8,7 +8,8 @@ var Style = require("../modules/components/style.js");
 
 var MEDIA_QUERIES = {
   md: '(min-width: 992px)',
-  lg: '(min-width: 1200px)'
+  lg: '(min-width: 1200px)',
+  smallOnly: '(max-width: 600px)'
 };
 
 MatchMediaBase.init(MEDIA_QUERIES);
@@ -44,6 +45,29 @@ var App = React.createClass({
               body: {
                 margin: 0,
                 fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif"
+              }
+            },
+            {
+              mediaQueries: {
+                smallOnly: [
+                  {
+                    body: {
+                      background: "gray"
+                    }
+                  }
+                ],
+                "(max-width: 500px)": [
+                  {
+                    body: {
+                      background: "blue"
+                    }
+                  },
+                  {
+                    "p, h1": {
+                      color: "white"
+                    }
+                  }
+                ]
               }
             }
           ]}

--- a/modules/components/style.js
+++ b/modules/components/style.js
@@ -49,27 +49,30 @@ var Style = React.createClass({
   },
 
   _buildMediaQueryString: function (mediaQueryObj) {
-    var mediaQueries = "";
+    var contextMediaQueries = this._getContextMediaQueries();
+    var mediaQueryString = "";
 
     Object.keys(mediaQueryObj).forEach(function (query) {
-      var completeQuery = this.contextMediaQueries[query] ?
-        this.contextMediaQueries[query] :
+      var completeQuery = contextMediaQueries[query] ?
+        contextMediaQueries[query] :
         query;
-      mediaQueries += "@media " + completeQuery + "{" +
+      mediaQueryString += "@media " + completeQuery + "{" +
         this._buildStyles(mediaQueryObj[query]) +
       "}";
     }.bind(this));
 
-    return mediaQueries;
+    return mediaQueryString;
   },
 
-  _prepareContextMediaQueries: function () {
-    this.contextMediaQueries = {};
+  _getContextMediaQueries: function () {
+    var contextMediaQueries = {};
     if (this.context && this.context.mediaQueries) {
       Object.keys(this.context.mediaQueries).forEach(function (query) {
-        this.contextMediaQueries[query] = this.context.mediaQueries[query].media;
+        contextMediaQueries[query] = this.context.mediaQueries[query].media;
       }.bind(this));
     }
+
+    return contextMediaQueries;
   },
 
   render: function () {
@@ -77,7 +80,6 @@ var Style = React.createClass({
       return null;
     }
 
-    this._prepareContextMediaQueries();
     var styles = this._buildStyles(this.props.rules);
 
     return React.createElement(

--- a/modules/mixins/match-media-base.js
+++ b/modules/mixins/match-media-base.js
@@ -54,7 +54,10 @@ var MatchMediaBase = {
 
   handleMediaChange: debounce(function () {
     for (var key in matchers) {
-      matchedQueries[key] = matchers[key].matches;
+      matchedQueries[key] = {
+        matches: matchers[key].matches,
+        media: matchers[key].media
+      }
     }
 
     this.forceUpdate();

--- a/modules/mixins/style-resolver.js
+++ b/modules/mixins/style-resolver.js
@@ -32,17 +32,19 @@ var StyleResolverMixin = {
       var key = Object.keys(mediaQueryObj)[0];
       var mediaQuery = mediaQueryObj[key];
 
-      if (componentMediaQueries && componentMediaQueries[key]) {
-        var activeMediaQuery = mediaQuery;
+      if (componentMediaQueries &&
+        componentMediaQueries[key] &&
+        componentMediaQueries[key].matches) {
+          var activeMediaQuery = mediaQuery;
 
-        if (!activeMediaQuery) {
-          return;
-        }
+          if (!activeMediaQuery) {
+            return;
+          }
 
-        merge(
-          mediaQueryStyles,
-          activeMediaQuery
-        );
+          merge(
+            mediaQueryStyles,
+            activeMediaQuery
+          );
       }
     });
 


### PR DESCRIPTION
This adds media query support to `Style`, which brings us one step closer to [server-side `Style` rendering](https://github.com/FormidableLabs/radium/issues/53#issuecomment-77470494).

To set up media queries, add a `mediaQueries` object to the `rules` array you pass to `Style`. Like `rules`, `mediaQueries` should be an array of objects with selectors as keys and style objects as values. You can use strings to define queries, as in
```
'(max-width: 500px)': [
  // styles
]
```
...or you can reuse previously `MatchMediaBase.init`ed queries, as in
```
MatchMediaBase.init({
  lg: '(min-width: 1200px)'
});

...

lg: [
  // styles
]
```
(The changes to `mixins/match-media-base` and `mixins/style-resolver` are to expose the `MatchMedia` queries via `MatchMediaItem`.)

/cc @alexlande 