### PR TITLE
Vendor prefixing

### DIFF
--- a/modules/__mocks__/prefix.js
+++ b/modules/__mocks__/prefix.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var prefixMock = function(style, mode) {
+  return style;
+};
+
+module.exports = prefixMock;

--- a/modules/prefix.js
+++ b/modules/prefix.js
@@ -3,7 +3,8 @@
  * shenanigans.
  */
 
-var camelCase = require('lodash/string/camelCase');
+'use strict';
+
 var kebabCase = require('lodash/string/kebabCase');
 
 var jsCssMap = {
@@ -25,11 +26,11 @@ for (var js in jsCssMap) {
   if ((js + testProp) in domStyle) {
     jsVendorPrefix = js;
     cssVendorPrefix = jsCssMap[js];
-    break
+    break;
   }
 }
 
-function _getPrefixedProperty(property) {
+var _getPrefixedProperty = function (property) {
   if (prefixedPropertyCache.hasOwnProperty(property)) {
     return prefixedPropertyCache[property];
   }
@@ -56,9 +57,9 @@ function _getPrefixedProperty(property) {
 
   // unsupported
   return prefixedPropertyCache[property] = false;
-}
+};
 
-function _getPrefixedValue(property, value) {
+var _getPrefixedValue = function (property, value) {
   // don't test numbers or numbers with units (e.g. 10em)
   if (typeof value !== 'string' || !isNaN(parseInt(value, 10))) {
     return value;
@@ -97,16 +98,15 @@ function _getPrefixedValue(property, value) {
   }
 
   return prefixedValueCache[cacheKey] = false;
-}
+};
 
-/**
- * Returns a new style object with vendor prefixes added to property names
- * and values.
- */
-function prefix(style, mode /* 'css' or 'js' */) {
+// Returns a new style object with vendor prefixes added to property names
+// and values.
+/*eslint-disable no-console */
+var prefix = function (style, mode /* 'css' or 'js' */) {
   mode = mode || 'js';
   var newStyle = {};
-  Object.keys(style).forEach(function(property) {
+  Object.keys(style).forEach(function (property) {
     var value = style[property];
 
     var newProperty = _getPrefixedProperty(property);
@@ -127,6 +127,7 @@ function prefix(style, mode /* 'css' or 'js' */) {
     newStyle[newProperty[mode]] = newValue;
   });
   return newStyle;
-}
+};
+/*eslint-enable no-console */
 
 module.exports = prefix;

--- a/modules/prefix.js
+++ b/modules/prefix.js
@@ -1,0 +1,113 @@
+/**
+ * Based on https://github.com/jsstyles/css-vendor, but without any dash-case
+ * shenanigans.
+ */
+
+var camelCase = require('lodash/string/camelCase');
+var kebabCase = require('lodash/string/kebabCase');
+
+var domStyle = document.createElement('p').style;
+var prefixedPropertyCache = {};
+var prefixedValueCache = {};
+var vendorPrefix = '';
+
+['Webkit', 'Moz', 'ms', 'O'].some(function(prefix) {
+  if ((prefix + 'Transform') in domStyle) {
+    vendorPrefix = prefix;
+    return true;
+  }
+  return false;
+});
+
+function _getPrefixedProperty(property) {
+  if (prefixedPropertyCache[property]) {
+    return prefixedPropertyCache[property];
+  }
+
+  if (property in domStyle) {
+    // unprefixed
+    return prefixedPropertyCache[property] = property;
+  }
+
+  var newProperty =
+    vendorPrefix + property[0].toUpperCase() + property.slice(1);
+  if (newProperty in domStyle) {
+    // prefixed
+    return prefixedPropertyCache[property] = newProperty;
+  }
+
+  // unsupported
+  return prefixedPropertyCache[property] = false;
+}
+
+function _getPrefixedValue(property, value) {
+  // don't test numbers or numbers with units (e.g. 10em)
+  if (typeof value !== 'string' || !isNaN(parseInt(value, 10))) {
+    return value;
+  }
+
+  var cacheKey = property + value;
+
+  if (prefixedValueCache[cacheKey]) {
+    return prefixedValueCache[cacheKey];
+  }
+
+  // Clear style first
+  domStyle[property] = '';
+
+  // Test value as it is.
+  domStyle[property] = value;
+
+  // Value is supported as it is. Note that we just make sure it is not an empty
+  // string. Browsers will sometimes rewrite values, but still accept them. They
+  // will set the value to an empty string if not supported.
+  // E.g. for border, "solid 1px black" becomes "1px solid black"
+  //      but "foobar" becomes "", since it is not supported.
+  if (domStyle[property]) {
+    prefixedValueCache[cacheKey] = value;
+    return value;
+  }
+
+  // Test value with vendor prefix.
+  value = vendorPrefix + value;
+  domStyle[property] = value;
+
+  // Value is supported with vendor prefix.
+  if (domStyle[property]) {
+    prefixedValueCache[cacheKey] = value;
+    return value;
+  }
+
+  return prefixedValueCache[cacheKey] = false;
+}
+
+/**
+ * Returns a new style object with vendor prefixes added to property names
+ * and values.
+ */
+function prefix(style) {
+  var newStyle = {};
+  Object.keys(style).forEach(function(property) {
+    var value = style[property];
+
+    var newProperty = _getPrefixedProperty(property);
+    if (newProperty === false) {
+      // Ignore unsupported properties
+      console.warn('Unsupported CSS property ' + property);
+      return;
+    }
+
+    var newValue = _getPrefixedValue(newProperty, value);
+    if (newValue === false) {
+      // Ignore unsupported values
+      console.warn(
+        'Unsupported CSS value ' + value + ' for property ' + property
+      );
+    }
+
+    newStyle[newProperty] = newValue;
+  });
+  return newStyle;
+}
+
+module.exports = prefix;

--- a/modules/prefix.js
+++ b/modules/prefix.js
@@ -6,18 +6,28 @@
 var camelCase = require('lodash/string/camelCase');
 var kebabCase = require('lodash/string/kebabCase');
 
+var jsCssMap = {
+    Webkit: '-webkit-',
+    Moz: '-moz-',
+    // IE did it wrong again ...
+    ms: '-ms-',
+    O: '-o-'
+};
+var testProp = 'Transform';
+
 var domStyle = document.createElement('p').style;
 var prefixedPropertyCache = {};
 var prefixedValueCache = {};
-var vendorPrefix = '';
+var propertyVendorPrefix = '';
+var valueVendorPrefix = '';
 
-['Webkit', 'Moz', 'ms', 'O'].some(function(prefix) {
-  if ((prefix + 'Transform') in domStyle) {
-    vendorPrefix = prefix;
-    return true;
+for (var js in jsCssMap) {
+  if ((js + testProp) in domStyle) {
+    propertyVendorPrefix = js;
+    valueVendorPrefix = jsCssMap[js];
+    break
   }
-  return false;
-});
+}
 
 function _getPrefixedProperty(property) {
   if (prefixedPropertyCache[property]) {
@@ -30,7 +40,7 @@ function _getPrefixedProperty(property) {
   }
 
   var newProperty =
-    vendorPrefix + property[0].toUpperCase() + property.slice(1);
+    propertyVendorPrefix + property[0].toUpperCase() + property.slice(1);
   if (newProperty in domStyle) {
     // prefixed
     return prefixedPropertyCache[property] = newProperty;
@@ -69,7 +79,7 @@ function _getPrefixedValue(property, value) {
   }
 
   // Test value with vendor prefix.
-  value = vendorPrefix + value;
+  value = valueVendorPrefix + value;
   domStyle[property] = value;
 
   // Value is supported with vendor prefix.

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var MouseUpListener = require('./mouse-up-listener');
+var prefix = require('./prefix');
+
 var React = require('react/addons');
 var clone = require('lodash/lang/clone');
 var isArray = require('lodash/lang/isArray');
@@ -137,7 +139,8 @@ var resolveStyles = function (component, renderedElement, existingKeyMap) {
     !Object.keys(style).some(_isSpecialKey)
   ) {
     if (style) {
-      newProps.style = style;
+      // Still perform vendor prefixing, though.
+      newProps.style = prefix(style);
       return React.cloneElement(renderedElement, newProps, newChildren);
     } else if (newChildren) {
       return React.cloneElement(renderedElement, {}, newChildren);
@@ -230,7 +233,7 @@ var resolveStyles = function (component, renderedElement, existingKeyMap) {
     );
   }
 
-  newProps.style = newStyle;
+  newProps.style = prefix(newStyle);
 
   return React.cloneElement(renderedElement, newProps, newChildren);
 };


### PR DESCRIPTION
Add some simple prefixing capability, based on [css-vendor](https://github.com/jsstyles/css-vendor). Don't use css-vendor directly, though, to avoid going back and forth between dash-case and camelCase. Also, be smarter than css-vendor about valid values that the browser rewrites.

While this approach works quite well, it falls down a bit for values that require complex prefixing. [PrefixFree](https://github.com/LeaVerou/prefixfree/) is much more comprehensive. For example, it will prefix values inside of `transition`, rewrite `linear-gradient`, and more.