### PR TITLE
Add css keyframes animation helper

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -2,4 +2,5 @@
 
 exports.Style = require('./components/style');
 exports.getState = require('./get-state');
+exports.keyframes = require('./keyframes');
 exports.wrap = require('./wrap');

--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var prefix = require('./prefix');
+
+var kebabCase = require('lodash/string/kebabCase');
+
+var msPrefix = /^ms-/;
+var animationIndex = 1;
+var animationStyleSheet = null;
+var keyframesPrefixed = null;
+
+if (document) {
+  animationStyleSheet = document.createElement('style');
+  document.head.appendChild(animationStyleSheet);
+
+  // Test if prefix needed for keyframes (copied from PrefixFree)
+  keyframesPrefixed = 'keyframes';
+  animationStyleSheet.textContent = '@keyframes {}';
+  if (!animationStyleSheet.sheet.cssRules.length) {
+    keyframesPrefixed = prefix.css + 'keyframes';
+  }
+}
+
+var createMarkupForStyles = function (style) {
+  return Object.keys(style).map(function (property) {
+    return kebabCase(property).replace(msPrefix, '-ms-') + ': ' +
+      style[property] + ';';
+  }).join('\n');
+};
+
+// Simple animation helper that injects CSS into a style object containing the
+// keyframes, and returns a string with the generated animation name.
+var keyframes = function (keyframes) {
+  var name = 'Animation' + animationIndex;
+  animationIndex += 1;
+
+  if (!document) {
+    return name;
+  }
+
+  var rule = '@' + keyframesPrefixed + ' ' + name + ' {\n' +
+    Object.keys(keyframes).map(function (percentage) {
+      var props = keyframes[percentage];
+      var prefixedProps = prefix(props, 'css');
+      var serializedProps = createMarkupForStyles(prefixedProps);
+      return '  ' + percentage + ' {\n  ' + serializedProps + '\n  }';
+    }).join('\n') +
+    '\n}\n';
+
+  animationStyleSheet.sheet.insertRule(
+    rule,
+    animationStyleSheet.sheet.cssRules.length
+  );
+  return name;
+};
+
+module.exports = keyframes;

--- a/modules/prefix.js
+++ b/modules/prefix.js
@@ -130,4 +130,7 @@ var prefix = function (style, mode /* 'css' or 'js' */) {
 };
 /*eslint-enable no-console */
 
+prefix.css = cssVendorPrefix;
+prefix.js = jsVendorPrefix;
+
 module.exports = prefix;


### PR DESCRIPTION
Fixes #52. Very simple to use:

```javascript
var pulseAnimation = Radium.animation({
  '0%': {width: '10%'},
  '50%': {width: '50%'},
  '100%': {width: '10%'}
});

var styles = {
  root: {
    animation: pulseAnimation + ' 3s ease 0s infinite'
  },
};
```