### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Travis Status](https://api.travis-ci.org/FormidableLabs/radium.svg)](https://travis-ci.org/FormidableLabs/radium)
+[![npm package](https://img.shields.io/npm/v/radium.svg)](https://www.npmjs.org/package/radium)
+[![dependency status](https://img.shields.io/david/FormidableLabs/radium.svg)](https://david-dm.org/FormidableLabs/radium)
 
 # Radium
 


### PR DESCRIPTION
Can someone with admin rights to FormidableLabs enable/setup TravisCI for Radium? Should probably run the lint and build the examples at least. Then I can add a "build passing" badge as well.