### PR TITLE
Add travis badge and config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+
+node_js:
+  - 0.10
+  - 0.12
+
+# Use container-based Travis infrastructure.
+sudo: false
+
+before_install:
+  # GUI for real browsers.
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+branches:
+  only:
+    - master
+
+script:
+  - node_modules/.bin/gulp check

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Travis Status](https://api.travis-ci.org/FormidableLabs/radium.svg)](https://travis-ci.org/FormidableLabs/radium)
+
 # Radium
 
 ```


### PR DESCRIPTION
As requested by @ianobermiller in #114 , I've enabled Travis builds on radium now. This PR adds a basic travis config that:

* Builds node v0.10, v0.12
* Is ready for karma FF tests
* Uses the new container-based infra
* Builds only against master pushes and PRs.

I'll let the folks who actually know what's going on in this repo suggest additional build / test targets ;)

/cc @alexlande 