### PR TITLE
Add Radium.getState API

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -76,6 +76,25 @@ var MyComponent = React.createClass(Radium.wrap({
 }));
 ```
 
+## Radium.getState(state, elementKey, value)
+
+Query Radium's knowledge of the browser state for a given element key. This is particularly useful if you would like to set styles for one element when another element is in a particular state, e.g. show a message when a button is hovered.
+
+Note that the target element specified by `elementKey` must have the state you'd like to check defined in its style object so that Radium knows to add the handlers. It can be empty, e.g. `':hover': {}`.
+
+Parameters:
+
+- **state** - you'll usually pass `this.state`, but sometimes you may want to pass a previous state, like in `shouldComponentUpdate`, `componentWillUpdate`, and `componentDidUpdate`
+- **elementKey** - if you used multiple elements, pass the same `key=""` or `ref=""`. If you only have one element, you can leave it blank (`'main'` will be inferred)
+- **value** - one of the following: `:active`, `:focus`, and `:hover`
+- **returns** `true` or `false`
+
+Usage:
+
+```javascript
+    Radium.getState(this.state, 'button', ':hover')
+```
+
 ## Style Component
 
 The `<Style>` component renders an HTML `<style>` tag containing a set of CSS rules. Using it, you can define an optional `scopeSelector` that all selectors in the resulting `<style>` element will include.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -225,3 +225,31 @@ var styles = {
   }
 };
 ```
+
+## Styling one element depending on another's state
+
+You can query Radium's state using `Radium.getState`. This allows you to style or render one element based on the state of another, e.g. showing a message when a button is hovered.
+
+```js
+var HoverMessage = React.createClass(Radium.wrap({
+  render: function () {
+    return (
+      <div>
+        <button key="button" style={[styles.button]}>Hover me!</button>
+        {Radium.getState(this.state, 'button', ':hover') ? (
+          <span>{' '}Hovering!</span>
+        ) : null}
+      </div>
+    )
+  }
+}));
+
+var styles = {
+  button: {
+    // Even though we don't have any special styles on the button, we need
+    // to add empty :hover styles here to tell Radium to track this element's
+    // state.
+    ':hover': {}
+  }
+};
+```

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -5,6 +5,31 @@ var ComputedWell = require("./components/computed-well.jsx");
 var Style = require("../modules/components/style.js");
 var Radium = require("../modules");
 
+var HoverMessage = React.createClass(Radium.wrap({
+  render: function () {
+    return (
+      <div>
+        <button key="button" style={{':hover': {}}}>Hover me!</button>
+        {Radium.getState(this.state, 'button', ':hover') ? (
+          <span>{' '}Hovering!</span>
+        ) : null}
+      </div>
+    )
+  }
+}));
+
+var TwoSquares = React.createClass(Radium.wrap({
+  render: function () {
+    return (
+      <div>
+        <div key="one" style={[squareStyles.both, squareStyles.one]} />
+        <div key="two" style={[squareStyles.both, squareStyles.two]} />
+        <div style={{clear: 'both'}} />
+      </div>
+    )
+  }
+}));
+
 var App = React.createClass(Radium.wrap({
 
   _remount: function() {
@@ -22,6 +47,10 @@ var App = React.createClass(Radium.wrap({
 
     return (
       <div>
+        <p><TwoSquares /></p>
+
+        <p><HoverMessage /></p>
+
         <p>
           <Button onClick={this._remount}>Unmount and remount</Button>
         </p>
@@ -107,6 +136,26 @@ var App = React.createClass(Radium.wrap({
     );
   }
 }));
+
+var squareStyles = {
+  both: {
+    background: 'black',
+    border: 'solid 1px white',
+    float: 'left',
+    height: 100,
+    width: 100
+  },
+  one: {
+    ':hover': {
+      background: 'blue',
+    }
+  },
+  two: {
+    ':hover': {
+      background: 'red',
+    }
+  }
+};
 
 var tileStyle = {
   display: 'block',

--- a/modules/__tests__/get-state-test.js
+++ b/modules/__tests__/get-state-test.js
@@ -1,0 +1,16 @@
+/* eslint-env jasmine */
+/* global jest */
+
+'use strict';
+
+jest.dontMock('../get-state.js');
+
+var getState = require('../get-state.js');
+
+describe('getState', function () {
+  it('throws on unknown value', function () {
+    expect(function () {
+      getState({}, null, 'unknown');
+    }).toThrow();
+  });
+});

--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -3,6 +3,7 @@
 
 'use strict';
 
+jest.dontMock('../get-state.js');
 jest.dontMock('../resolve-styles.js');
 
 var React = require('react');

--- a/modules/__tests__/wrap-test.js
+++ b/modules/__tests__/wrap-test.js
@@ -23,8 +23,9 @@ describe('wrap', function () {
       render: function () { return null; }
     });
 
+
     expect(wrapped.getInitialState()).toEqual(
-      {_radiumStyleState: {}, foo: 'bar'}
+      {foo: 'bar', _radiumStyleState: {}}
     );
   });
 

--- a/modules/get-state.js
+++ b/modules/get-state.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var VALID_KEYS = [':active', ':focus', ':hover'];
+
+var getState = function (state, elementKey, value) {
+  elementKey = elementKey || 'main';
+
+  if (VALID_KEYS.indexOf(value) === -1) {
+    throw new Error('Radium.getState invalid value param: `' + value + '`');
+  }
+
+  return (
+    state &&
+    state._radiumStyleState &&
+    state._radiumStyleState[elementKey] &&
+    state._radiumStyleState[elementKey][value]
+  ) || false;
+};
+
+module.exports = getState;

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,4 +1,5 @@
 'use strict';
 
 exports.Style = require('./components/style');
+exports.getState = require('./get-state');
 exports.wrap = require('./wrap');

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var MouseUpListener = require('./mouse-up-listener');
+var getState = require('./get-state');
+
 var React = require('react/addons');
 var clone = require('lodash/lang/clone');
 var isArray = require('lodash/lang/isArray');
@@ -14,10 +16,7 @@ var _isSpecialKey = function (key) {
 };
 
 var _getStyleState = function (component, key, value) {
-  return component.state &&
-    component.state._radiumStyleState &&
-      component.state._radiumStyleState[key] &&
-        component.state._radiumStyleState[key][value];
+  return getState(component.state, key, value);
 };
 
 var _setStyleState = function (component, key, newState) {
@@ -43,8 +42,8 @@ var _mergeStyles = function (styles) {
 
 var _mouseUp = function (component) {
   Object.keys(component.state._radiumStyleState).forEach(function (key) {
-    if (_getStyleState(component, key, 'isActive')) {
-      _setStyleState(component, key, {isActive: false});
+    if (_getStyleState(component, key, ':active')) {
+      _setStyleState(component, key, {':active': false});
     }
   });
 };
@@ -180,13 +179,13 @@ var resolveStyles = function (component, renderedElement, existingKeyMap) {
     var existingOnMouseEnter = props.onMouseEnter;
     newProps.onMouseEnter = function (e) {
       existingOnMouseEnter && existingOnMouseEnter(e);
-      _setStyleState(component, key, { isHovering: true });
+      _setStyleState(component, key, {':hover': true});
     };
 
     var existingOnMouseLeave = props.onMouseLeave;
     newProps.onMouseLeave = function (e) {
       existingOnMouseLeave && existingOnMouseLeave(e);
-      _setStyleState(component, key, { isHovering: false });
+      _setStyleState(component, key, {':hover': false});
     };
   }
 
@@ -195,7 +194,7 @@ var resolveStyles = function (component, renderedElement, existingKeyMap) {
     newProps.onMouseDown = function (e) {
       existingOnMouseDown && existingOnMouseDown(e);
       component._lastMouseDown = Date.now();
-      _setStyleState(component, key, { isActive: true });
+      _setStyleState(component, key, {':active': true});
     };
   }
 
@@ -203,22 +202,22 @@ var resolveStyles = function (component, renderedElement, existingKeyMap) {
     var existingOnFocus = props.onFocus;
     newProps.onFocus = function (e) {
       existingOnFocus && existingOnFocus(e);
-      _setStyleState(component, key, { isFocused: true });
+      _setStyleState(component, key, {':focus': true});
     };
 
     var existingOnBlur = props.onBlur;
     newProps.onBlur = function (e) {
       existingOnBlur && existingOnBlur(e);
-      _setStyleState(component, key, { isFocused: false });
+      _setStyleState(component, key, {':focus': false});
     };
   }
 
   // Merge the styles in the order they were defined
   Object.keys(style).forEach(function (name) {
     if (
-      (name === ':active' && _getStyleState(component, key, 'isActive')) ||
-      (name === ':hover' && _getStyleState(component, key, 'isHovering')) ||
-      (name === ':focus' && _getStyleState(component, key, 'isFocused'))
+      (name === ':active' && _getStyleState(component, key, ':active')) ||
+      (name === ':hover' && _getStyleState(component, key, ':hover')) ||
+      (name === ':focus' && _getStyleState(component, key, ':focus'))
     ) {
       merge(newStyle, style[name]);
     }

--- a/modules/wrap.js
+++ b/modules/wrap.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var merge = require('lodash/object/merge');
 var resolveStyles = require('./resolve-styles.js');
+
+var merge = require('lodash/object/merge');
 
 var wrap = function (config) {
   var newConfig = {
@@ -9,7 +10,7 @@ var wrap = function (config) {
       var existingInitialState = config.getInitialState ?
         config.getInitialState.call(this) :
         {};
-      return merge({}, existingInitialState, { _radiumStyleState: {} });
+      return merge({}, existingInitialState, {_radiumStyleState: {}});
     },
 
     componentWillUnmount: function () {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ],
     "collectCoverage": true,
     "collectCoverageOnlyFrom": {
+      "modules/get-state.js": true,
       "modules/resolve-styles.js": true,
       "modules/wrap.js": true
     },


### PR DESCRIPTION
Re-opening from #113.

>Add Radium.getState API for querying Radium's internal state. Especially useful when you want to style or render one element depending on the state of another. Addresses #107.

- @ianobermiller 