### PR TITLE
Add Enhancer for using Radium with ES6 classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ When we say expressive, we mean it: math, concatenation, regex, conditionals, fu
 * Media queries
 * Automatic vendor prefixing
 * Keyframes animation helper
+* ES6 class and `createClass` support
 
 ## Docs
 
@@ -43,7 +44,7 @@ When we say expressive, we mean it: math, concatenation, regex, conditionals, fu
 
 ## Usage
 
-Start by adding `Radium.wrap()` around the config you pass to `React.createClass`. Then, write a style object as you normally would with inline styles, and add in styles for interactive states and media queries. Pass the style object to your component via `style={...}` and let Radium do the rest!
+Start by adding `Radium.Enhancer()` around your component, like `module.exports = Radium.Enhancer(Component)`, or `Component = Radium.Enhancer(Component)`. Alternatively, if using `createClass`, add `Radium.wrap()` around the config you pass to `React.createClass`. Then, write a style object as you normally would with inline styles, and add in styles for interactive states and media queries. Pass the style object to your component via `style={...}` and let Radium do the rest!
 
 ```as
 <Button kind="primary">Radium Button</Button>
@@ -54,18 +55,42 @@ var Radium = require('radium');
 var React = require('react');
 var color = require('color');
 
-var Button = React.createClass(Radium.wrap({
-  propTypes: {
-    kind: React.PropTypes.oneOf(['primary', 'warning']).isRequired
-  },
-
-  render: function () {
+// Radium is the cleanest when using ES6 classes with React.
+class Button extends React.Component {
+  render() {
     // Radium extends the style attribute to accept an array. It will merge
     // the styles in order. We use this feature here to apply the primary
     // or warning styles depending on the value of the `kind` prop. Since its
     // all just JavaScript, you can use whatever logic you want to decide which
     // styles are applied (props, state, context, etc). Radium also adds vendor
     // prefixes automatically where needed.
+    return (
+      <button
+        style={[
+          styles.base,
+          this.props.kind === 'primary' && styles.primary,
+          this.props.kind === 'warning' && styles.warning
+        ]}>
+        {this.props.children}
+      </button>
+    );
+  }
+}
+Button.propTypes = {
+  kind: React.PropTypes.oneOf(['primary', 'warning']).isRequired
+};
+
+// Add Radium support to your ES6 class component
+module.exports = Radium.Enhancer(Button);
+
+
+// You can also use React.createClass
+var Button = React.createClass(Radium.wrap({
+  propTypes: {
+    kind: React.PropTypes.oneOf(['primary', 'warning']).isRequired
+  },
+
+  render: function () {
     return (
       <button
         style={[

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2,11 +2,28 @@
 
 **Table of Contents**
 
+- [Enhancer](#enhancer)
 - [getState](#getstate)
 - [keyframes](#keyframes)
 - [wrap](#wrap)
   - [Sample Style Object](#sample-style-object)
 - [Style Component](#style-component)
+
+## Enhancer
+```as
+module.exports = Radium.Enhancer(Button);
+
+// or
+Button = Radium.Enhancer(Button);
+
+// or if using Decorators (Stage 1, Babel)
+@Radium.Enhancer
+class Button extends React.Component {
+  // ...
+}
+```
+
+`Enhancer` is the ES6 verison of `wrap`. See [documentation for wrap](#wrap) to see how it works.
 
 ## getState
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,6 +6,20 @@ Radium is a toolset for easily writing React component styles. It resolves brows
 
 Let's create a fictional `<Button>` component. It will have a set of default styles, will adjust its appearance based on modifiers, and will include hover, focus, and active states.
 
+**Using ES6 classes**
+```as
+class Button extends React.Component {
+  render() {
+    return (
+      <button>
+        {this.props.children}
+      </button>
+    );
+  }
+}
+```
+
+**Using createClass**
 ```as
 var Button = React.createClass({
   render: function () {
@@ -18,8 +32,23 @@ var Button = React.createClass({
 });
 ```
 
-Radium is activated by wrapping your component configuration:
+Radium is activated by wrapping your component or its configuration:
 
+**Using ES6 classes**
+```as
+module.exports = Radium.Enhancer(Button);
+
+// or
+Button = Radium.Enhancer(Button);
+
+// or if using Decorators (Stage 1, Babel)
+@Radium.Enhancer
+class Button extends React.Component {
+  // ...
+}
+```
+
+**Using createClass**
 ```as
 var Button = React.createClass(Radium.wrap({
   render: function () { ... }
@@ -55,15 +84,12 @@ var styles = {
 Next, simply pass your styles to the `style` attribute of an element:
 
 ```as
-var Button = React.createClass(Radium.wrap({
-  render: function () {
-    return (
-      <button style={styles.base}>
-        {this.props.children}
-      </button>
-    )
-  }
-}));
+// Inside render
+return (
+  <button style={styles.base}>
+    {this.props.children}
+  </button>
+);
 ```
 
 From there, React will apply our styles to the `button` element. This is not very exciting. In fact, React does this by default, without the extra step of using `Radium.wrap()`. Radium becomes useful when you need to do more complex things, like handling modifiers, states, and media queries. But, even without those complex things, Radium will still merge an array of styles and automatically apply vendor prefixes for you.
@@ -101,19 +127,16 @@ var styles = {
 Then, include that style object in the array passed to the `style` attribute if the conditions match:
 
 ```as
-var Button = React.createClass(Radium.wrap({
-  render: function () {
-    return (
-      <button
-        style={[
-          styles.base,
-          this.props.block && styles.block
-        ]}>
-        {this.props.children}
-      </button>
-    )
-  }
-}));
+// Inside render
+return (
+  <button
+    style={[
+      styles.base,
+      this.props.block && styles.block
+    ]}>
+    {this.props.children}
+  </button>
+);
 ```
 
 Radium will ignore any elements of the array that aren't objects, such as the result of `this.props.block && styles.block` when `this.props.block` is `false` or `undefined`.
@@ -201,16 +224,13 @@ If you use the query `@media print`, your print styles will not show up on Firef
 Radium allows you to style multiple elements in the same component. You just have to give each element that has browser state modifiers like :hover or media queries a unique `key` or `ref` attribute:
 
 ```as
-var TwoSquares = React.createClass(Radium.wrap({
-  render: function () {
-    return (
-      <div>
-        <div key="one" style={[styles.both, styles.one]} />
-        <div key="two" style={[styles.both, styles.two]} />
-      </div>
-    )
-  }
-}));
+// Inside render
+return (
+  <div>
+    <div key="one" style={[styles.both, styles.one]} />
+    <div key="two" style={[styles.both, styles.two]} />
+  </div>
+);
 
 var styles = {
   both: {
@@ -237,18 +257,15 @@ var styles = {
 You can query Radium's state using `Radium.getState`. This allows you to style or render one element based on the state of another, e.g. showing a message when a button is hovered.
 
 ```js
-var HoverMessage = React.createClass(Radium.wrap({
-  render: function () {
-    return (
-      <div>
-        <button key="button" style={[styles.button]}>Hover me!</button>
-        {Radium.getState(this.state, 'button', ':hover') ? (
-          <span>{' '}Hovering!</span>
-        ) : null}
-      </div>
-    )
-  }
-}));
+// Inside render
+return (
+  <div>
+    <button key="button" style={[styles.button]}>Hover me!</button>
+    {Radium.getState(this.state, 'button', ':hover') ? (
+      <span>{' '}Hovering!</span>
+    ) : null}
+  </div>
+);
 
 var styles = {
   button: {

--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -719,7 +719,7 @@ describe('resolveStyles', function () {
   });
 
   describe('React.Children.only', function () {
-    it.only('doesn\'t break React.Children.only', function () {
+    it('doesn\'t break React.Children.only', function () {
       var component = genComponent();
       var renderedElement = <div><span /></div>;
 
@@ -728,7 +728,7 @@ describe('resolveStyles', function () {
       expect(React.Children.only(result.props.children)).toBeTruthy();
     });
 
-    it.only('doesn\'t break when only child isn\'t ReactElement', function () {
+    it('doesn\'t break when only child isn\'t ReactElement', function () {
       var component = genComponent();
       var renderedElement = <div>Foo</div>;
 

--- a/modules/__tests__/wrap-test.js
+++ b/modules/__tests__/wrap-test.js
@@ -4,6 +4,7 @@
 'use strict';
 
 jest.dontMock('../wrap.js');
+jest.dontMock('../wrap-utils.js');
 
 var resolveStyles = require('../resolve-styles.js');
 var wrap = require('../wrap.js');

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -33,6 +33,7 @@ var enhanceWithRadium = function (ComposedComponent) {
     wrapUtils.componentWillUnmount(this);
   };
 
+  RadiumEnhancer.defaultProps = ComposedComponent.defaultProps;
   RadiumEnhancer.propTypes = ComposedComponent.propTypes;
   RadiumEnhancer.contextTypes = ComposedComponent.contextTypes;
 

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -1,14 +1,21 @@
+'use strict';
+
 var resolveStyles = require('./resolve-styles.js');
 var wrapUtils = require('./wrap-utils.js');
 
-module.exports = function enhanceWithRadium(ComposedComponent) {
-  function RadiumEnhancer () {
+var enhanceWithRadium = function (ComposedComponent) {
+  var RadiumEnhancer = function () {
     ComposedComponent.prototype.constructor.call(this);
+
+    if (!this.state) {
+      this.state = {};
+    }
+
     var radiumInitialState = wrapUtils.getInitialState();
     Object.keys(radiumInitialState).forEach(function (key) {
       this.state[key] = radiumInitialState[key];
     }, this);
-  }
+  };
 
   RadiumEnhancer.prototype = new ComposedComponent();
   RadiumEnhancer.prototype.constructor = RadiumEnhancer;
@@ -31,3 +38,5 @@ module.exports = function enhanceWithRadium(ComposedComponent) {
 
   return RadiumEnhancer;
 };
+
+module.exports = enhanceWithRadium;

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -1,0 +1,33 @@
+var resolveStyles = require('./resolve-styles.js');
+var wrapUtils = require('./wrap-utils.js');
+
+module.exports = function enhanceWithRadium(ComposedComponent) {
+  function RadiumEnhancer () {
+    ComposedComponent.prototype.constructor.call(this);
+    var radiumInitialState = wrapUtils.getInitialState();
+    Object.keys(radiumInitialState).forEach(function (key) {
+      this.state[key] = radiumInitialState[key];
+    }, this);
+  }
+
+  RadiumEnhancer.prototype = new ComposedComponent();
+  RadiumEnhancer.prototype.constructor = RadiumEnhancer;
+
+  RadiumEnhancer.prototype.render = function () {
+    var renderedElement = ComposedComponent.prototype.render.call(this);
+    return resolveStyles(this, renderedElement);
+  };
+
+  RadiumEnhancer.prototype.componentWillUnmount = function () {
+    if (ComposedComponent.prototype.componentWillUnmount) {
+      ComposedComponent.prototype.componentWillUnmount.call(this);
+    }
+
+    wrapUtils.componentWillUnmount(this);
+  };
+
+  RadiumEnhancer.propTypes = ComposedComponent.propTypes;
+  RadiumEnhancer.contextTypes = ComposedComponent.contextTypes;
+
+  return RadiumEnhancer;
+};

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+exports.Enhancer = require('./enhancer');
 exports.Style = require('./components/style');
 exports.getState = require('./get-state');
 exports.keyframes = require('./keyframes');

--- a/modules/wrap-utils.js
+++ b/modules/wrap-utils.js
@@ -1,0 +1,20 @@
+module.exports = {
+  getInitialState: function () {
+    return {_radiumStyleState: {}};
+  },
+
+  componentWillUnmount: function (component) {
+    if (component._radiumMouseUpListener) {
+      component._radiumMouseUpListener.remove();
+    }
+
+    if (component._radiumMediaQueryListenersByQuery) {
+      Object.keys(component._radiumMediaQueryListenersByQuery).forEach(
+        function (query) {
+          component._radiumMediaQueryListenersByQuery[query].remove();
+        },
+        component
+      );
+    }
+  }
+};

--- a/modules/wrap-utils.js
+++ b/modules/wrap-utils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   getInitialState: function () {
     return {_radiumStyleState: {}};

--- a/modules/wrap.js
+++ b/modules/wrap.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var resolveStyles = require('./resolve-styles.js');
+var wrapUtils = require('./wrap-utils.js');
 
 var merge = require('lodash/object/merge');
 
@@ -10,24 +11,13 @@ var wrap = function (config) {
       var existingInitialState = config.getInitialState ?
         config.getInitialState.call(this) :
         {};
-      return merge({}, existingInitialState, {_radiumStyleState: {}});
+      var radiumInitialState = wrapUtils.getInitialState();
+      return merge({}, existingInitialState, radiumInitialState);
     },
 
     componentWillUnmount: function () {
       config.componentWillUnmount && config.componentWillUnmount.call(this);
-
-      if (this._radiumMouseUpListener) {
-        this._radiumMouseUpListener.remove();
-      }
-
-      if (this._radiumMediaQueryListenersByQuery) {
-        Object.keys(this._radiumMediaQueryListenersByQuery).forEach(
-          function (query) {
-            this._radiumMediaQueryListenersByQuery[query].remove();
-          },
-          this
-        );
-      }
+      wrapUtils.componentWillUnmount(this);
     },
 
     render: function () {


### PR DESCRIPTION
I'm not really sure about the naming conventions, but this is a "higher order component". I've also played around with the idea of calling it a Decorator, since it can be used as-is as an ES7 decorator (https://github.com/wycats/javascript-decorators). We might also consider exposing `wrapUtils` (to satisfy cases like #123), although I'm not sure it is worth expanding the API surface.

Fixes #122.