### PR TITLE
Feature: Add babel compilation on prepublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 _site
 npm-debug.log
 coverage
+lib

--- a/modules/components/style.js
+++ b/modules/components/style.js
@@ -82,9 +82,8 @@ var Style = React.createClass({
 
     var styles = this._buildStyles(this.props.rules);
 
-    return React.createElement(
-      'style',
-      {dangerouslySetInnerHTML: {__html: styles}}
+    return (
+      <style dangerouslySetInnerHTML={{__html: styles}} />
     );
   }
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "radium",
   "version": "0.11.1",
   "description": "A set of tools to manage inline styles on React elements",
-  "main": "modules/index.js",
+  "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/formidablelabs/radium.git"
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "dist": "webpack && webpack --config=webpack.config.minified.js",
+    "lib": "rm -rf ./lib && babel ./modules -d lib && rm -rf ./lib/__tests__ ./lib/__mocks__",
     "examples": "webpack-dev-server --config examples/webpack.config.js --no-info --content-base examples/",
     "test": "jest",
     "lint": "eslint modules"
@@ -26,10 +27,12 @@
     "lodash": "^3.2.0"
   },
   "devDependencies": {
+    "babel": "^5.3.1",
+    "babel-core": "^5.3.1",
+    "babel-loader": "^5.0.0",
     "coveralls": "^2.11.2",
     "eslint": "^0.19.0",
     "jest-cli": "^0.4.0",
-    "jsx-loader": "^0.12.2",
     "react": ">=0.12.0 <0.14.0",
     "react-tools": "^0.13.3",
     "webpack": "^1.5.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,12 +16,8 @@ module.exports = {
   module: {
     loaders: [
       {
-        test: /\.js$/,
-        loader: 'jsx-loader?harmony'
-      },
-      {
-        test: /\.jsx$/,
-        loader: 'jsx-loader?insertPragma=React.DOM&harmony'
+        test: /\.js(x|)?$/,
+        loader: 'babel-loader'
       }
     ]
   }


### PR DESCRIPTION
This revisits the compiling Radium with babel thing. Includes a set up to compile our modules to a `.gitignore`'d `lib` directory.

We can either do this on `prepublish` or in a `publish.sh`. I wasn't really sure what the best option was. The weird thing about `prepublish` is that it runs on `npm install`, not just before the package is published. See https://github.com/npm/npm/issues/3059 for a very long discussion about that.

If we do something like a `publish.sh` script that includes `npm run lib` and `npm publish`, we wouldn't slow down `npm install` for everyone.

If anyone has opinions on that...

/cc @ianobermiller @kenwheeler 