### PR TITLE
Replaceable matchMedia() function for server side rendering

### DIFF
--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -5,11 +5,13 @@
 
 jest.dontMock('../get-state.js');
 jest.dontMock('../resolve-styles.js');
+jest.dontMock('../config.js');
 
 var React = require('react');
 var MouseUpListener = require('../mouse-up-listener.js');
 var objectAssign = require('object-assign');
 var resolveStyles = require('../resolve-styles.js');
+var Config = require('../config.js');
 
 var genComponent = function () {
   return {
@@ -507,9 +509,10 @@ describe('resolveStyles', function () {
     it('listens for media queries', function () {
       var component = genComponent();
       var addListener = jest.genMockFunction();
-      window.matchMedia = jest.genMockFunction().mockImplementation(function () {
+      var matchMedia = jest.genMockFunction().mockImplementation(function () {
         return {addListener: addListener};
       });
+      Config.setMatchMedia(matchMedia);
 
       var renderedElement =
         <div style={{
@@ -517,16 +520,17 @@ describe('resolveStyles', function () {
         }} />;
 
       resolveStyles(component, renderedElement);
-      expect(window.matchMedia).lastCalledWith('(max-width: 400px)');
+      expect(matchMedia).lastCalledWith('(max-width: 400px)');
       expect(addListener).lastCalledWith(jasmine.any('function'));
     });
 
     it('only listens once for a single element', function () {
       var component = genComponent();
       var addListener = jest.genMockFunction();
-      window.matchMedia = jest.genMockFunction().mockImplementation(function () {
+      var matchMedia = jest.genMockFunction().mockImplementation(function () {
         return {addListener: addListener};
       });
+      Config.setMatchMedia(matchMedia);
 
       var renderedElement =
         <div style={{
@@ -536,7 +540,7 @@ describe('resolveStyles', function () {
       resolveStyles(component, renderedElement);
       resolveStyles(component, renderedElement);
 
-      expect(window.matchMedia.mock.calls.length).toBe(1);
+      expect(matchMedia.mock.calls.length).toBe(1);
       expect(addListener.mock.calls.length).toBe(1);
     });
 
@@ -544,9 +548,10 @@ describe('resolveStyles', function () {
       var component1 = genComponent();
       var component2 = genComponent();
       var addListener = jest.genMockFunction();
-      window.matchMedia = jest.genMockFunction().mockImplementation(function () {
+      var matchMedia = jest.genMockFunction().mockImplementation(function () {
         return {addListener: addListener};
       });
+      Config.setMatchMedia(matchMedia);
 
       var renderedElement =
         <div>
@@ -563,18 +568,19 @@ describe('resolveStyles', function () {
       resolveStyles(component1, renderedElement);
       resolveStyles(component2, renderedElement);
 
-      expect(window.matchMedia.mock.calls.length).toBe(1);
+      expect(matchMedia.mock.calls.length).toBe(1);
       expect(addListener.mock.calls.length).toBe(2);
     });
 
     it('applies styles when media query matches', function () {
       var component = genComponent();
-      window.matchMedia = jest.genMockFunction().mockImplementation(function () {
+      var matchMedia = jest.genMockFunction().mockImplementation(function () {
         return {
           addListener: jest.genMockFunction(),
           matches: true
         };
       });
+      Config.setMatchMedia(matchMedia);
 
       var renderedElement =
         <div style={{
@@ -588,12 +594,13 @@ describe('resolveStyles', function () {
 
     it('merges nested pseudo styles', function () {
       var component = genComponent();
-      window.matchMedia = jest.genMockFunction().mockImplementation(function () {
+      var matchMedia = jest.genMockFunction().mockImplementation(function () {
         return {
           addListener: jest.genMockFunction(),
           matches: true
         };
       });
+      Config.setMatchMedia(matchMedia);
 
       var renderedElement =
         <div style={[
@@ -639,9 +646,10 @@ describe('resolveStyles', function () {
         }
       );
       var mql = {addListener: addListener};
-      window.matchMedia = jest.genMockFunction().mockImplementation(function () {
+      var matchMedia = jest.genMockFunction().mockImplementation(function () {
         return mql;
       });
+      Config.setMatchMedia(matchMedia);
 
       var renderedElement =
         <div style={{
@@ -664,9 +672,10 @@ describe('resolveStyles', function () {
         addListener: jest.genMockFunction(),
         removeListener: jest.genMockFunction()
       };
-      window.matchMedia = jest.genMockFunction().mockImplementation(function () {
+      var matchMedia = jest.genMockFunction().mockImplementation(function () {
         return mql;
       });
+      Config.setMatchMedia(matchMedia);
 
       var renderedElement =
         <div style={{

--- a/modules/config.js
+++ b/modules/config.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+'use strict';
+
+var ExecutionEnvironment = require('exenv');
+
+var _matchMediaFunction = ExecutionEnvironment.canUseDOM &&
+  window &&
+  window.matchMedia;
+
+module.exports = {
+  canMatchMedia () {
+    return typeof _matchMediaFunction === 'function';
+  },
+
+  matchMedia (query: string) {
+    return _matchMediaFunction(query);
+  },
+
+  setMatchMedia (nextMatchMediaFunction: Function) {
+    _matchMediaFunction = nextMatchMediaFunction;
+  }
+};

--- a/modules/index.js
+++ b/modules/index.js
@@ -6,3 +6,4 @@ module.exports = (ComposedComponent: constructor) => Enhancer(ComposedComponent)
 module.exports.Style = require('./components/style');
 module.exports.getState = require('./get-state');
 module.exports.keyframes = require('./keyframes');
+module.exports.Config = require('./config');

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -5,6 +5,7 @@
 var MouseUpListener = require('./mouse-up-listener');
 var getState = require('./get-state');
 var Prefixer = require('./prefixer');
+var Config = require('./config');
 
 var ExecutionEnvironment = require('exenv');
 var React = require('react');
@@ -75,11 +76,7 @@ var _onMediaQueryChange = function (component, query, mediaQueryList) {
 };
 
 var _resolveMediaQueryStyles = function (component, style) {
-  if (
-    !ExecutionEnvironment.canUseDOM ||
-    !window ||
-    !window.matchMedia
-  ) {
+  if (!Config.canMatchMedia()) {
     return style;
   }
 
@@ -92,7 +89,7 @@ var _resolveMediaQueryStyles = function (component, style) {
     // Create a global MediaQueryList if one doesn't already exist
     var mql = mediaQueryListByQueryString[query];
     if (!mql) {
-      mediaQueryListByQueryString[query] = mql = window.matchMedia(query);
+      mediaQueryListByQueryString[query] = mql = Config.matchMedia(query);
     }
 
     // Keep track of which keys already have listeners


### PR DESCRIPTION
Hi! We are using this fork both for server side rendering and generating mobile device preview on client side.

It replaces the ```window.matchMedia()``` calls with ```Radium.matchMedia()``` which is working like a strategy so you can replace the currently used matchMedia function like ```Radium.matchMedia.replace(iframe.contentWindow.matchMedia)```

It provides [css-mediaquery](https://github.com/ericf/css-mediaquery) based substitution for ```window.matchMedia()``` (```MatchMediaMock```) so it can be used with only js on the server side.

ex:
```javascript
var Radium = require('radium');
var matchMediaMock = require('radium/modules/match-media-mock');
Radium.matchMedia.replace(matchMediaMock);

app.get('/app/:width/:height', function(req, res) {
  
  matchMediaMock.setConfig({
    type: 'screen',
    width: req.params.width,
    height: req.params.height,
  });
  
  var html = React.renderToString(<RadiumApp/>);
  
  res.end(html);
});
```
As you see, it's not a full solution for the server side rendering because you have to be able to send some information about the client device in the request. I don't know whether this use case support is among your goals but if so, and you like this approach i would be happy to prepare this to be mergeable.