### PR TITLE
Remove lodash to make the distributed build smaller

### DIFF
--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -8,13 +8,13 @@ jest.dontMock('../resolve-styles.js');
 
 var React = require('react');
 var MouseUpListener = require('../mouse-up-listener.js');
-var merge = require('lodash/object/merge');
+var objectAssign = require('object-assign');
 var resolveStyles = require('../resolve-styles.js');
 
 var genComponent = function () {
   return {
     setState: jest.genMockFunction().mockImplementation(function (newState) {
-      this.state = merge(this.state, newState);
+      objectAssign(this.state, newState);
     }),
     state: {}
   };

--- a/modules/components/style.js
+++ b/modules/components/style.js
@@ -2,7 +2,6 @@
 
 var React = require('react');
 var CSSPropertyOperations = require('react/lib/CSSPropertyOperations');
-var reduce = require('lodash/collection/reduce');
 
 var buildCssString = function (selector, rules) {
   if (!selector || !rules) {
@@ -28,7 +27,7 @@ var Style = React.createClass({
   },
 
   _buildStyles: function (stylesArr) {
-    var styles = reduce(stylesArr, function (accumulator, item) {
+    var styles = stylesArr.reduce((accumulator, item) => {
       var selector = Object.keys(item)[0];
       var rules = item[selector];
 
@@ -43,7 +42,7 @@ var Style = React.createClass({
       }
 
       return accumulator;
-    }, '', this);
+    }, '');
 
     return styles;
   },

--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -3,9 +3,7 @@
 var prefix = require('./prefix');
 
 var ExecutionEnvironment = require('exenv');
-var kebabCase = require('lodash/string/kebabCase');
 
-var msPrefix = /^ms-/;
 var animationIndex = 1;
 var animationStyleSheet = null;
 var keyframesPrefixed = null;
@@ -24,8 +22,7 @@ if (ExecutionEnvironment.canUseDOM) {
 
 var createMarkupForStyles = function (style) {
   return Object.keys(style).map(function (property) {
-    return kebabCase(property).replace(msPrefix, '-ms-') + ': ' +
-      style[property] + ';';
+    return property + ': ' + style[property] + ';';
   }).join('\n');
 };
 

--- a/modules/wrap.js
+++ b/modules/wrap.js
@@ -3,7 +3,7 @@
 var resolveStyles = require('./resolve-styles.js');
 var wrapUtils = require('./wrap-utils.js');
 
-var merge = require('lodash/object/merge');
+var objectAssign = require('object-assign');
 
 var wrap = function (config) {
   var newConfig = {
@@ -12,7 +12,7 @@ var wrap = function (config) {
         config.getInitialState.call(this) :
         {};
       var radiumInitialState = wrapUtils.getInitialState();
-      return merge({}, existingInitialState, radiumInitialState);
+      return objectAssign({}, existingInitialState, radiumInitialState);
     },
 
     componentWillUnmount: function () {
@@ -26,7 +26,7 @@ var wrap = function (config) {
     }
   };
 
-  return merge({}, config, newConfig);
+  return objectAssign({}, config, newConfig);
 };
 
 module.exports = wrap;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "exenv": "^1.1.0",
-    "lodash": "^3.2.0"
+    "object-assign": "^2.0.0"
   },
   "devDependencies": {
     "babel": "^5.3.3",
@@ -37,6 +37,7 @@
     "coveralls": "^2.11.2",
     "eslint": "^0.19.0",
     "jest-cli": "^0.4.0",
+    "lodash": "^3.2.0",
     "react": ">=0.12.0 <0.14.0",
     "rimraf": "^2.3.3",
     "webpack": "^1.5.3",
@@ -59,6 +60,7 @@
     "unmockedModulePathPatterns": [
       "exenv",
       "lodash",
+      "object-assign",
       "react"
     ]
   }


### PR DESCRIPTION
- Use object-assign instead of lodash merge
- Replace generic kebabCase with a more compact and specific version
- Reduces gzipped size of Radium distribution from 10,366 bytes to 4,093 bytes

```bash
~/dev/radium git master
➜ gzip < dist/radium.min.js | wc -c
   10366

~/dev/radium git reduce-size
➜ gzip < dist/radium.min.js | wc -c
    4093
```