### PR TITLE
Move dependencies required by lib out of dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
   },
   "dependencies": {
     "exenv": "^1.1.0",
-    "object-assign": "^2.0.0"
-  },
-  "devDependencies": {
+    "object-assign": "^2.0.0",
+
     "babel": "^5.3.3",
     "babel-core": "^5.3.3",
+    "rimraf": "^2.3.3"
+  },
+  "devDependencies": {
     "babel-eslint": "^3.1.1",
     "babel-loader": "^5.0.0",
     "coveralls": "^2.11.2",
@@ -40,7 +42,6 @@
     "jest-cli": "^0.4.0",
     "lodash": "^3.2.0",
     "react": ">=0.12.0 <0.14.0",
-    "rimraf": "^2.3.3",
     "webpack": "^1.5.3",
     "webpack-dev-server": "^1.7.0"
   },


### PR DESCRIPTION
Fixes #169, installing directly from git instead of through a published NPM build.