### PR TITLE
Fix test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ branches:
 
 script:
   - npm run lint
-  - npm run test
+  - npm run test-coverage
   # Upload to coveralls, but don't _fail_ if coveralls is down.
   - cat coverage/lcov.info | node_modules/.bin/coveralls || echo "Coveralls upload failed"

--- a/jest/coverage-config.json
+++ b/jest/coverage-config.json
@@ -1,0 +1,22 @@
+{
+  "rootDir": "..",
+  "scriptPreprocessor": "jest/preprocessor.js",
+  "testPathDirs": [
+    "lib"
+  ],
+  "collectCoverage": true,
+  "collectCoverageOnlyFrom": {
+    "lib/enhancer.js": true,
+    "lib/get-state.js": true,
+    "lib/prefix.js": true,
+    "lib/resolve-styles.js": true,
+    "lib/wrap-utils.js": true,
+    "lib/wrap.js": true
+  },
+  "unmockedModulePathPatterns": [
+    "exenv",
+    "lodash",
+    "object-assign",
+    "react"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
     "example": "examples"
   },
   "scripts": {
+    "babel": "rimraf lib && babel --stage 0 modules/ -d lib/",
     "dist": "webpack && webpack --config=webpack.config.minified.js",
     "examples": "webpack-dev-server --config examples/webpack.config.js --no-info --content-base examples/",
-    "lib": "rimraf lib && babel --stage 0 modules/ -d lib/ && rimraf lib/__tests__ lib/__mocks__",
+    "lib": "npm run babel && rimraf lib/__tests__ lib/__mocks__",
     "lint": "eslint modules",
     "postinstall": "node -e \"require('fs').readdir('lib',function(e){e&&require('child_process').spawn('npm', ['run', 'prepublish'], {stdio: 'inherit'})})\"",
     "prepublish": "npm run lib",
     "test": "jest",
-    "test-coverage": "jest --coverage"
+    "test-coverage": "npm run babel && jest --config jest/coverage-config.json"
   },
   "license": "MIT",
   "peerDependencies": {
@@ -50,15 +51,6 @@
     "testPathDirs": [
       "modules"
     ],
-    "collectCoverage": false,
-    "collectCoverageOnlyFrom": {
-      "modules/enhancer.js": true,
-      "modules/get-state.js": true,
-      "modules/prefix.js": true,
-      "modules/resolve-styles.js": true,
-      "modules/wrap-utils.js": true,
-      "modules/wrap.js": true
-    },
     "unmockedModulePathPatterns": [
       "exenv",
       "lodash",


### PR DESCRIPTION
Fixes #168.
- `test-coverage` now transforms `modules/` into `lib/` before running
to avoid transpile issues with coverage
- separate coverage into separate jest config
- update travis config