### PR TITLE
Fix IE9 when using keyframes

### DIFF
--- a/jest/coverage-config.json
+++ b/jest/coverage-config.json
@@ -9,7 +9,7 @@
     "lib/enhancer.js": true,
     "lib/get-state.js": true,
     "lib/keyframes.js": true,
-    "lib/prefix.js": true,
+    "lib/prefixer.js": true,
     "lib/resolve-styles.js": true,
     "lib/wrap-utils.js": true,
     "lib/wrap.js": true

--- a/modules/__mocks__/prefix.js
+++ b/modules/__mocks__/prefix.js
@@ -1,9 +1,0 @@
-'use strict';
-
-var prefixMock = function (style) {
-  return style;
-};
-
-prefixMock.css = '-webkit-';
-
-module.exports = prefixMock;

--- a/modules/__mocks__/prefixer.js
+++ b/modules/__mocks__/prefixer.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var nextPrefixedPropertyName = null;
+
+module.exports = {
+  getPrefixedPropertyName: name => {
+    if (nextPrefixedPropertyName !== null) {
+      name = nextPrefixedPropertyName;
+      nextPrefixedPropertyName = null;
+    }
+    return name;
+  },
+  getPrefixedStyle: style => style,
+  cssPrefix: '-webkit-',
+
+  __setNextPrefixedPropertyName (name) {
+    nextPrefixedPropertyName = name;
+  }
+};

--- a/modules/__tests__/keyframes-test.js
+++ b/modules/__tests__/keyframes-test.js
@@ -37,12 +37,25 @@ describe('keyframes', () => {
     window.getComputedStyle = originalWindowGetComputedStyle;
   });
 
-  it('doesn\t touch the DOM if not available', () => {
+  it('doesn\'t touch the DOM if DOM not available', () => {
     jest.setMock('exenv', {
       canUseDOM: false,
       canUseEventListeners: false
     });
 
+    var keyframes = require('../keyframes.js');
+
+    expect(document.createElement).not.toBeCalled();
+    expect(document.head.appendChild).not.toBeCalled();
+
+    var name = keyframes({});
+
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it('doesn\'t touch the DOM if animation not supported (IE9)', () => {
+    var Prefixer = require('../prefixer.js');
+    Prefixer.__setNextPrefixedPropertyName(false);
     var keyframes = require('../keyframes.js');
 
     expect(document.createElement).not.toBeCalled();
@@ -59,13 +72,24 @@ describe('keyframes', () => {
     expect(name.length).toBeGreaterThan(0);
   });
 
-  it('prefixes @keyframes', () => {
+  it('prefixes @keyframes if needed', () => {
     var keyframes = require('../keyframes.js');
     var name = keyframes({});
 
     expect(styleElement.sheet.insertRule).lastCalledWith(
       '@-webkit-keyframes ' + name + ' {\n\n}\n',
       0
+    );
+  });
+
+  it('doesn\'t prefix @keyframes if not needed', () => {
+    styleElement.sheet.cssRules = [{cssText: 'blah'}];
+    var keyframes = require('../keyframes.js');
+    var name = keyframes({});
+
+    expect(styleElement.sheet.insertRule).lastCalledWith(
+      '@keyframes ' + name + ' {\n\n}\n',
+      1
     );
   });
 

--- a/modules/__tests__/prefixer-test.js
+++ b/modules/__tests__/prefixer-test.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-jest.dontMock('../prefix.js');
+jest.dontMock('../prefixer.js');
 
 var originalDocumentCreateElement = document.createElement;
 var originalWindowGetComputedStyle = window.getComputedStyle;
@@ -11,7 +11,7 @@ var originalWindowGetComputedStyle = window.getComputedStyle;
 var browserPrefix = '';
 var mockStyle = {};
 
-describe('prefix', () => {
+describe('Prefixer', () => {
   beforeEach(() => {
     browserPrefix = '';
     mockStyle = {};
@@ -36,30 +36,30 @@ describe('prefix', () => {
 
   it('detects Firefox prefix', () => {
     browserPrefix = '-moz-';
-    var prefix = require('../prefix.js');
-    expect(prefix.css).toBe('-moz-');
-    expect(prefix.js).toBe('Moz');
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.cssPrefix).toBe('-moz-');
+    expect(Prefixer.jsPrefix).toBe('Moz');
   });
 
   it('detects IE prefix', () => {
     browserPrefix = '-ms-';
-    var prefix = require('../prefix.js');
-    expect(prefix.css).toBe('-ms-');
-    expect(prefix.js).toBe('ms');
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.cssPrefix).toBe('-ms-');
+    expect(Prefixer.jsPrefix).toBe('ms');
   });
 
   it('detects Opera prefix', () => {
     browserPrefix = '-o-';
-    var prefix = require('../prefix.js');
-    expect(prefix.css).toBe('-o-');
-    expect(prefix.js).toBe('O');
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.cssPrefix).toBe('-o-');
+    expect(Prefixer.jsPrefix).toBe('O');
   });
 
   it('detects Webkit prefix', () => {
     browserPrefix = '-webkit-';
-    var prefix = require('../prefix.js');
-    expect(prefix.css).toBe('-webkit-');
-    expect(prefix.js).toBe('Webkit');
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.cssPrefix).toBe('-webkit-');
+    expect(Prefixer.jsPrefix).toBe('Webkit');
   });
 
   it('doesn\'t detect prefix if not in browser', () => {
@@ -68,12 +68,12 @@ describe('prefix', () => {
       canUseEventListeners: false
     });
 
-    var prefix = require('../prefix.js');
-    var result = prefix({display: 'flex'});
+    var Prefixer = require('../prefixer.js');
+    var result = Prefixer.getPrefixedStyle({display: 'flex'});
 
     expect(result).toEqual({display: 'flex'});
-    expect(prefix.css).toBe('');
-    expect(prefix.js).toBe('');
+    expect(Prefixer.cssPrefix).toBe('');
+    expect(Prefixer.jsPrefix).toBe('');
     expect(document.createElement).not.toBeCalled();
     expect(window.getComputedStyle).not.toBeCalled();
   });
@@ -81,8 +81,8 @@ describe('prefix', () => {
   it('uses unprefixed property if in style object', () => {
     browserPrefix = '-webkit-';
     mockStyle = { transform: '' };
-    var prefix = require('../prefix.js');
-    expect(prefix({transform: 'foo'})).toEqual({transform: 'foo'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({transform: 'foo'})).toEqual({transform: 'foo'});
   });
 
   it('caches property and value checks', () => {
@@ -92,30 +92,30 @@ describe('prefix', () => {
       get transform () { return transformGetter(); },
       set transform (value) { }
     };
-    var prefix = require('../prefix.js');
-    prefix({transform: 'foo'});
-    prefix({transform: 'foo'});
+    var Prefixer = require('../prefixer.js');
+    Prefixer.getPrefixedStyle({transform: 'foo'});
+    Prefixer.getPrefixedStyle({transform: 'foo'});
     expect(transformGetter.mock.calls.length).toBe(1);
   });
 
   it('ignores property if not in style object', () => {
-    var prefix = require('../prefix.js');
+    var Prefixer = require('../prefixer.js');
     mockStyle = {};
-    expect(prefix({transform: 'foo'})).toEqual({});
+    expect(Prefixer.getPrefixedStyle({transform: 'foo'})).toEqual({});
   });
 
   it('uses prefixed property if unprefixed not in style object', () => {
     browserPrefix = '-webkit-';
     mockStyle = { WebkitTransform: '' };
-    var prefix = require('../prefix.js');
-    expect(prefix({transform: 'foo'})).toEqual({WebkitTransform: 'foo'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({transform: 'foo'})).toEqual({WebkitTransform: 'foo'});
   });
 
   it('uses alternative properties if no others available', () => {
     browserPrefix = '-moz-';
     mockStyle = { MozBoxFlex: '' };
-    var prefix = require('../prefix.js');
-    expect(prefix({flex: 1})).toEqual({MozBoxFlex: 1});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({flex: 1})).toEqual({MozBoxFlex: 1});
   });
 
   it('uses prefixed property if both in style object', () => {
@@ -124,15 +124,15 @@ describe('prefix', () => {
       transform: '',
       WebkitTransform: ''
     };
-    var prefix = require('../prefix.js');
-    expect(prefix({transform: 'foo'})).toEqual({WebkitTransform: 'foo'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({transform: 'foo'})).toEqual({WebkitTransform: 'foo'});
   });
 
   it('uses unprefixed value if setter works', () => {
     browserPrefix = '-webkit-';
     mockStyle = { transform: '' };
-    var prefix = require('../prefix.js');
-    expect(prefix({transform: 'foo'})).toEqual({transform: 'foo'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({transform: 'foo'})).toEqual({transform: 'foo'});
   });
 
   it('ignores unsupported values', () => {
@@ -141,20 +141,20 @@ describe('prefix', () => {
       get transform () { return ''; },
       set transform (value) { }
     };
-    var prefix = require('../prefix.js');
-    expect(prefix({transform: 'foo'})).toEqual({transform: 'foo'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({transform: 'foo'})).toEqual({transform: 'foo'});
   });
 
   it('ignores number values', () => {
     mockStyle = { lineHeight: '' };
-    var prefix = require('../prefix.js');
-    expect(prefix({lineHeight: 2})).toEqual({lineHeight: 2});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({lineHeight: 2})).toEqual({lineHeight: 2});
   });
 
   it('ignores numbers with units', () => {
     mockStyle = { lineHeight: '' };
-    var prefix = require('../prefix.js');
-    expect(prefix({lineHeight: '2em'})).toEqual({lineHeight: '2em'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({lineHeight: '2em'})).toEqual({lineHeight: '2em'});
   });
 
   it('uses prefixed value if unprefixed setter fails and it works', () => {
@@ -170,8 +170,8 @@ describe('prefix', () => {
         }
       }
     };
-    var prefix = require('../prefix.js');
-    expect(prefix({display: 'flex'})).toEqual({display: '-webkit-flex'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({display: 'flex'})).toEqual({display: '-webkit-flex'});
   });
 
   it('uses alternative value if all others fail and it works', () => {
@@ -187,16 +187,16 @@ describe('prefix', () => {
         }
       }
     };
-    var prefix = require('../prefix.js');
-    expect(prefix({display: 'flex'})).toEqual({display: '-webkit-box'});
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({display: 'flex'})).toEqual({display: '-webkit-box'});
   });
 
   it('uses dash-case if mode is css', () => {
     mockStyle = {
       borderWidth: '1px'
     };
-    var prefix = require('../prefix.js');
-    expect(prefix({borderWidth: '1px'}, 'css')).toEqual(
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({borderWidth: '1px'}, 'css')).toEqual(
       {'border-width': '1px'}
     );
   });
@@ -206,8 +206,8 @@ describe('prefix', () => {
     mockStyle = {
       WebkitBorderWidth: ''
     };
-    var prefix = require('../prefix.js');
-    expect(prefix({borderWidth: '1px'}, 'css')).toEqual(
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({borderWidth: '1px'}, 'css')).toEqual(
       {'-webkit-border-width': '1px'}
     );
   });

--- a/modules/components/style.js
+++ b/modules/components/style.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var createMarkupForStyles = require('../create-markup-for-styles');
-var prefix = require('../prefix');
+var Prefixer = require('../prefixer');
 
 var React = require('react');
 
@@ -10,7 +10,7 @@ var buildCssString = function (selector, rules) {
     return;
   }
 
-  var prefixedRules = prefix(rules, 'css');
+  var prefixedRules = Prefixer.getPrefixedStyle(rules, 'css');
   var serializedRules = createMarkupForStyles(prefixedRules);
 
   return selector + '{' + serializedRules + '}';

--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -3,15 +3,18 @@
 'use strict';
 
 var createMarkupForStyles = require('./create-markup-for-styles');
-var prefix = require('./prefix');
+var Prefixer = require('./prefixer');
 
 var ExecutionEnvironment = require('exenv');
+
+var isAnimationSupported = ExecutionEnvironment.canUseDOM &&
+  Prefixer.getPrefixedPropertyName('animation') !== false;
 
 var animationIndex = 1;
 var animationStyleSheet = null;
 var keyframesPrefixed = null;
 
-if (ExecutionEnvironment.canUseDOM) {
+if (isAnimationSupported) {
   animationStyleSheet = (document.createElement('style'): any);
   document.head.appendChild(animationStyleSheet);
 
@@ -19,7 +22,7 @@ if (ExecutionEnvironment.canUseDOM) {
   keyframesPrefixed = 'keyframes';
   animationStyleSheet.textContent = '@keyframes {}';
   if (!animationStyleSheet.sheet.cssRules.length) {
-    keyframesPrefixed = prefix.css + 'keyframes';
+    keyframesPrefixed = Prefixer.cssPrefix + 'keyframes';
   }
 }
 
@@ -31,14 +34,14 @@ var keyframes = function (
   var name = 'Animation' + animationIndex;
   animationIndex += 1;
 
-  if (!ExecutionEnvironment.canUseDOM) {
+  if (!isAnimationSupported) {
     return name;
   }
 
   var rule = '@' + keyframesPrefixed + ' ' + name + ' {\n' +
     Object.keys(keyframeRules).map(function (percentage) {
       var props = keyframeRules[percentage];
-      var prefixedProps = prefix(props, 'css');
+      var prefixedProps = Prefixer.getPrefixedStyle(props, 'css');
       var serializedProps = createMarkupForStyles(prefixedProps, '  ');
       return '  ' + percentage + ' {\n  ' + serializedProps + '\n  }';
     }).join('\n') +

--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -84,7 +84,7 @@ var _camelCaseToDashCase = function (s) {
   return s.replace(_camelCaseRegex, _camelCaseReplacer);
 };
 
-var _getPrefixedProperty = function (property) {
+var getPrefixedPropertyName = function (property) {
   if (prefixedPropertyCache.hasOwnProperty(property)) {
     return prefixedPropertyCache[property];
   }
@@ -195,7 +195,7 @@ var _getPrefixedValue = function (property, value, originalProperty) {
 
 // Returns a new style object with vendor prefixes added to property names
 // and values.
-var prefix = function (style, mode /* 'css' or 'js' */) {
+var getPrefixedStyle = function (style, mode /* 'css' or 'js' */) {
   mode = mode || 'js';
 
   if (!ExecutionEnvironment.canUseDOM) {
@@ -206,7 +206,7 @@ var prefix = function (style, mode /* 'css' or 'js' */) {
   Object.keys(style).forEach(function (property) {
     var value = style[property];
 
-    var newProperty = _getPrefixedProperty(property);
+    var newProperty = getPrefixedPropertyName(property);
     if (newProperty === false) {
       // Ignore unsupported properties
       /* eslint-disable no-console */
@@ -224,7 +224,10 @@ var prefix = function (style, mode /* 'css' or 'js' */) {
   return newStyle;
 };
 
-prefix.css = prefixInfo.cssPrefix;
-prefix.js = prefixInfo.jsPrefix;
 
-module.exports = prefix;
+module.exports = {
+  getPrefixedPropertyName,
+  getPrefixedStyle,
+  cssPrefix: prefixInfo.cssPrefix,
+  jsPrefix: prefixInfo.jsPrefix
+};

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -4,7 +4,7 @@
 
 var MouseUpListener = require('./mouse-up-listener');
 var getState = require('./get-state');
-var prefix = require('./prefix');
+var Prefixer = require('./prefixer');
 
 var ExecutionEnvironment = require('exenv');
 var React = require('react');
@@ -176,7 +176,7 @@ var resolveStyles = function (
   ) {
     if (style) {
       // Still perform vendor prefixing, though.
-      newProps.style = prefix(style);
+      newProps.style = Prefixer.getPrefixedStyle(style);
       return React.cloneElement(renderedElement, newProps, newChildren);
     } else if (newChildren) {
       return React.cloneElement(renderedElement, {}, newChildren);
@@ -279,7 +279,7 @@ var resolveStyles = function (
     );
   }
 
-  newProps.style = prefix(newStyle);
+  newProps.style = Prefixer.getPrefixedStyle(newStyle);
 
   return React.cloneElement(renderedElement, newProps, newChildren);
 };


### PR DESCRIPTION
- Bail out on keyframes if animation not supported at all
- Refactor `prefix` into `Prefixer`
- References #127