### PR TITLE
fix resolving ReactComponentElement children

### DIFF
--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -761,4 +761,18 @@ describe('resolveStyles', function () {
     });
   });
 
+  describe('ReactComponentElement children', function () {
+    it('doesn\'t change ReactComponentElement children', function () {
+      var component = genComponent();
+      class CustomComponent extends React.Component {}
+      var style = {':hover': {}};
+      var renderedElement = <div>
+        <CustomComponent style={style}/>
+      </div>;
+
+      var result = resolveStyles(component, renderedElement);
+      var children = getChildrenArray(result.props.children);
+      expect(children[0].props.style).toBe(style);
+    });
+  });
 });

--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -762,17 +762,48 @@ describe('resolveStyles', function () {
   });
 
   describe('ReactComponentElement children', function () {
-    it('doesn\'t change ReactComponentElement children', function () {
+    it('doesn\'t resolve ReactComponentElement children', function () {
       var component = genComponent();
       class CustomComponent extends React.Component {}
       var style = {':hover': {}};
-      var renderedElement = <div>
+      var renderedElement = (<div>
         <CustomComponent style={style}/>
-      </div>;
+      </div>);
 
       var result = resolveStyles(component, renderedElement);
       var children = getChildrenArray(result.props.children);
       expect(children[0].props.style).toBe(style);
+    });
+
+    it('resolves ReactDOMElement children of ReactComponentElements', function () {
+      var component = genComponent();
+      class CustomComponent extends React.Component {}
+      var style = [
+        {background: 'white'},
+        {color: 'blue'}
+      ];
+      var renderedElement = (
+        <div style={style}>
+          <CustomComponent style={style}>
+            <div style={style} />
+          </CustomComponent>
+        </div>
+      );
+
+      var result = resolveStyles(component, renderedElement);
+      expect(result.props.style).toEqual({
+        background: 'white',
+        color: 'blue'
+      });
+
+      var children = getChildrenArray(result.props.children);
+      expect(children[0].props.style).toBe(style);
+
+      var componentChildren = getChildrenArray(children[0].props.children);
+      expect(componentChildren[0].props.style).toEqual({
+        background: 'white',
+        color: 'blue'
+      });
     });
   });
 });

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -137,6 +137,14 @@ var resolveStyles = function (
   // will not be here, so each component needs to use Radium.
   var newChildren = null;
   var oldChildren = renderedElement.props.children;
+  var resolveChild = function (child) {
+    // test if child is a valid ReactDOMElement and not ReactComponentElement
+    if (React.isValidElement(child) && typeof child.type === 'string') {
+      return resolveStyles(component, child, existingKeyMap);
+    }
+
+    return child;
+  };
   if (oldChildren) {
     var childrenType = typeof oldChildren;
     if (childrenType === 'string' || childrenType === 'number') {
@@ -146,13 +154,13 @@ var resolveStyles = function (
       // If a React Element is an only child, don't wrap it in an array for
       // React.Children.map() for React.Children.only() compatibility.
       var onlyChild = React.Children.only(oldChildren);
-      newChildren = resolveStyles(component, onlyChild, existingKeyMap);
+      newChildren = resolveChild(onlyChild);
     } else {
       newChildren = React.Children.map(
         oldChildren,
         function (child) {
           if (React.isValidElement(child)) {
-            return resolveStyles(component, child, existingKeyMap);
+            return resolveChild(child);
           }
 
           return child;


### PR DESCRIPTION
Currently Radium resolves all the childrens of the enhanced element which can lead to some unexpected behavior and affect the performance badly. 
ex:
```javascript
<MyRadiumComponent>
  <ThirdPartyComponent/>
  <div/>
</MyRadiumComponent>
```
The ```ThirdPartyComponent``` and it's children will be resolved, not just the ```div``` 

```javascript
<MyRadiumComponent>
  <MyRadiumComponent>
    <MyRadiumComponent/>
  </MyRadiumComponent>
</MyRadiumComponent>
```
The inner ```MyRadiumComponent```-s will be added to the ```resolveStyles()``` multiple times.

I added a failing test for this and a possible fix which is only resolve ```ReactDOMElement```-s when it recurse over the children in the ```resolveStyles()``` and skips the ``ReactComponentElement```-s.