### PR TITLE
add basic suport for mediaQuery aliases

### DIFF
--- a/modules/config.js
+++ b/modules/config.js
@@ -7,6 +7,7 @@ var ExecutionEnvironment = require('exenv');
 var _matchMediaFunction = ExecutionEnvironment.canUseDOM &&
   window &&
   window.matchMedia;
+var _mediaQueryAliases = new Map();
 
 module.exports = {
   canMatchMedia () {
@@ -19,5 +20,24 @@ module.exports = {
 
   setMatchMedia (nextMatchMediaFunction: Function) {
     _matchMediaFunction = nextMatchMediaFunction;
+  },
+
+  setMediaQueryAlias (alias: string, query: string) {
+    if (alias.indexOf('@') !== 0) {
+      throw new Error('alias should start with "@"');
+    }
+    if (query.indexOf('@media ') !== 0) {
+      throw new Error('query should start with "@media "');
+    }
+
+    _mediaQueryAliases.set(alias, query);
+  },
+
+  getMediaQueryByAlias (alias: string) {
+    return _mediaQueryAliases.get(alias);
+  },
+
+  isMediaQueryAlias (alias: string):boolean {
+    return _mediaQueryAliases.has(alias);
   }
 };

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -84,6 +84,10 @@ var _resolveMediaQueryStyles = function (component, style) {
   .filter(function (name) { return name[0] === '@'; })
   .map(function (query) {
     var mediaQueryStyles = style[query];
+
+    if (Config.isMediaQueryAlias(query)) {
+      query = Config.getMediaQueryByAlias(query);
+    }
     query = query.replace('@media ', '');
 
     // Create a global MediaQueryList if one doesn't already exist


### PR DESCRIPTION
Regards [this](https://github.com/FormidableLabs/radium/pull/146#issuecomment-101845152) and [this](https://github.com/FormidableLabs/radium/pull/101#issuecomment-94955913) comment i implemented a possible way to use named media queries.

It's pretty simple:
```javascript
var alias = '@portrait';
var query = '@media only screen and (max-width: 768px) and (orientation: portrait)';
Radium.Config.setMediaQueryAlias(alias, query);
```

and inside the ```resolveMediaQueryStyles()``` function it replaces the the alias to the query 
```javascript
if (Config.isMediaQueryAlias(query)) {
  query = Config.getMediaQueryByAlias(query);
}
```

In our use case we saving the styles into JSON so it's shrinks the file size and makes it easier to edit the mediaQueries later.

What do you think?