### PR TITLE
Prefixer fixes for server rendering

### DIFF
--- a/modules/__tests__/prefixer-test.js
+++ b/modules/__tests__/prefixer-test.js
@@ -62,7 +62,7 @@ describe('Prefixer', () => {
     expect(Prefixer.jsPrefix).toBe('Webkit');
   });
 
-  it('doesn\'t detect prefix if not in browser', () => {
+  it('doesn\'t detect prefix if in server', () => {
     jest.setMock('exenv', {
       canUseDOM: false,
       canUseEventListeners: false
@@ -218,6 +218,30 @@ describe('Prefixer', () => {
     expect(Prefixer.getPrefixedStyle({borderWidth: '1px'}, 'css')).toEqual(
       {'border-width': '1px'}
     );
+  });
+
+  it('uses dash-case if mode is css and in server', () => {
+    jest.setMock('exenv', {
+      canUseDOM: false,
+      canUseEventListeners: false
+    });
+
+    var Prefixer = require('../prefixer.js');
+    expect(Prefixer.getPrefixedStyle({borderWidth: '1px'}, 'css')).toEqual(
+      {'border-width': '1px'}
+    );
+  });
+
+  it('uses first value in fallback array if in server', () => {
+    jest.setMock('exenv', {
+      canUseDOM: false,
+      canUseEventListeners: false
+    });
+
+    var Prefixer = require('../prefixer.js');
+    expect(
+      Prefixer.getPrefixedStyle({color: ['rgba(255, 255, 255, .5)', '#fff']})
+    ).toEqual({color: 'rgba(255, 255, 255, .5)'});
   });
 
   it('uses dash-prefix if mode is css', () => {

--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -208,7 +208,13 @@ var getPrefixedStyle = function (style, mode /* 'css' or 'js' */) {
   mode = mode || 'js';
 
   if (!ExecutionEnvironment.canUseDOM) {
-    return style;
+    return Object.keys(style).reduce((newStyle, key) => {
+      var value = style[key];
+      var newKey = mode === 'css' ? _camelCaseToDashCase(key) : key;
+      var newValue = Array.isArray(value) ? value[0] : value;
+      newStyle[newKey] = newValue;
+      return newStyle;
+    }, {});
   }
 
   var newStyle = {};


### PR DESCRIPTION
- Fixes #207, not using dash-case on server with Style
- Fixes another latent bug, when using a fallback array as value, the
server should pick the first one (not perfect, since it will mean older
browsers will be more likely to have to throw out state)