### PR TITLE
Fixes #228: Fix warning when mixing longhand and shorthand props

### DIFF
--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -827,12 +827,12 @@ describe('resolveStyles', function () {
   /* eslint-disable no-console */
   describe('warnings', function () {
     beforeEach(function () {
-      this.originalConsoleWarning = console.warning;
-      console.warning = jest.genMockFunction();
+      this.originalConsoleWarning = console.warn;
+      console.warn = jest.genMockFunction();
     });
 
     afterEach(function () {
-      console.warning = this.originalConsoleWarning;
+      console.warn = this.originalConsoleWarning;
       process.env.NODE_ENV = null;
     });
 
@@ -847,8 +847,8 @@ describe('resolveStyles', function () {
 
       resolveStyles(component, renderedElement);
 
-      expect(console.warning).toBeCalled();
-      expect(console.warning.mock.calls[0][0].indexOf('border'))
+      expect(console.warn).toBeCalled();
+      expect(console.warn.mock.calls[0][0].indexOf('border'))
         .toBeGreaterThan(0);
     });
 
@@ -865,8 +865,8 @@ describe('resolveStyles', function () {
 
       resolveStyles(component, renderedElement);
 
-      expect(console.warning).toBeCalled();
-      expect(console.warning.mock.calls[0][0].indexOf('border'))
+      expect(console.warn).toBeCalled();
+      expect(console.warn.mock.calls[0][0].indexOf('border'))
         .toBeGreaterThan(0);
     });
   });

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -206,7 +206,7 @@ var resolveStyles = function (
           keys.some(k => k !== shorthand && k.indexOf(shorthand) === 0)
         ) {
           /* eslint-disable no-console */
-          console.warning(
+          console.warn(
             'Radium: property "' + shorthand + '" in style object',
             style,
             ': do not mix longhand and ' +


### PR DESCRIPTION
`console.warning` was called rather than `console.warn` in the original PR.