### PR TITLE
ensuring that defaultProps get transferred in every browser

### DIFF
--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -44,6 +44,10 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
     }
   }
 
+  if (ComposedComponent.hasOwnProperty('defaultProps')) {
+    RadiumEnhancer.defaultProps = ComposedComponent.defaultProps;
+  }
+
   RadiumEnhancer.displayName = `Radium(${displayName})`;
 
   return RadiumEnhancer;

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -44,9 +44,18 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
     }
   }
 
-  if (ComposedComponent.hasOwnProperty('defaultProps')) {
-    RadiumEnhancer.defaultProps = ComposedComponent.defaultProps;
-  }
+  var staticKeys = [
+    'defaultProps',
+    'propTypes',
+    'contextTypes',
+    'childContextTypes'
+  ];
+
+  staticKeys.forEach((key) => {
+    if (ComposedComponent.hasOwnProperty(key)) {
+      RadiumEnhancer[key] = ComposedComponent[key];
+    }
+  });
 
   RadiumEnhancer.displayName = `Radium(${displayName})`;
 

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -44,6 +44,10 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
     }
   }
 
+  // Class inheritance uses Object.create and because of __proto__ issues
+  // with IE <10 any static properties of the superclass aren't inherited and
+  // so need to be manually populated
+  // See http://babeljs.io/docs/advanced/caveats/#classes-10-and-below-
   var staticKeys = [
     'defaultProps',
     'propTypes',


### PR DESCRIPTION
This fixes #235, and doesn't require a move away from using the subclass method in order to enhance components.