### PR TITLE
Warn & ignore when receiving null or undefined values

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -147,7 +147,7 @@ rules:
     no-undef: 2                    # disallow use of undeclared variables unless mentioned in a
                                    #    /*global */ block
     no-undef-init: 2               # disallow use of undefined when initializing variables
-    no-undefined: 2                # disallow use of undefined variable
+    no-undefined: 0                # disallow use of undefined variable
     no-unused-vars: 2              # disallow declaration of variables that are not used in
                                    #    the code
     no-use-before-define: 2        # disallow use of variables before they are defined

--- a/modules/__tests__/prefixer-test.js
+++ b/modules/__tests__/prefixer-test.js
@@ -149,6 +149,18 @@ describe('Prefixer', () => {
     expect(Prefixer.getPrefixedStyle({lineHeight: '2em'})).to.deep.equal({lineHeight: '2em'});
   });
 
+  it('ignores null values', () => {
+    mockStyle = { lineHeight: '' };
+    var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
+    expect(Prefixer.getPrefixedStyle({lineHeight: null})).to.deep.equal({lineHeight: null});
+  });
+
+  it('ignores undefined values', () => {
+    mockStyle = { lineHeight: '' };
+    var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
+    expect(Prefixer.getPrefixedStyle({lineHeight: undefined})).to.deep.equal({lineHeight: undefined});
+  });
+
   it('uses prefixed value if unprefixed setter fails and it works', () => {
     browserPrefix = '-webkit-';
     var flexValue = '';

--- a/modules/__tests__/prefixer-test.js
+++ b/modules/__tests__/prefixer-test.js
@@ -158,7 +158,9 @@ describe('Prefixer', () => {
   it('ignores undefined values', () => {
     mockStyle = { lineHeight: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle({lineHeight: undefined})).to.deep.equal({lineHeight: undefined});
+    expect(
+      Prefixer.getPrefixedStyle({lineHeight: undefined})).to.deep.equal({lineHeight: undefined}
+    );
   });
 
   it('uses prefixed value if unprefixed setter fails and it works', () => {

--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -191,6 +191,7 @@ var _getPrefixedValue = function (property, value, originalProperty) {
         if (console && console.warn) {
           console.warn('CSS value is "' + value + '" for property "' + property + '"');
         }
+        return value;
       }
     }
 

--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -184,7 +184,14 @@ var _getPrefixedValue = function (property, value, originalProperty) {
     }
 
     if (typeof value !== 'string') {
-      value = value.toString();
+      if (value !== null && value !== undefined) {
+        value = value.toString();
+      } else {
+        /* eslint-disable no-console */
+        if (console && console.warn) {
+          console.warn('CSS value is "' + value + '" for property "' + property + '"');
+        }
+      }
     }
 
     // don't test numbers with units (e.g. 10em)


### PR DESCRIPTION
Title says it all!

I also added a couple of tests and made a change to `.eslintrc` to allow the use of `undefined` since we need to compare against it & use it for testing.

Closes #245.