### PR TITLE
extending prototype functions in order to fix hot loader

### DIFF
--- a/modules/__tests__/enhancer-test.js
+++ b/modules/__tests__/enhancer-test.js
@@ -6,32 +6,6 @@ var Enhancer = require('inject!enhancer.js')({
 var {Component} = require('react');
 
 describe('Enhancer', () => {
-  it('sets up initial state', () => {
-    class Composed extends Component { }
-    var Enhanced = Enhancer(Composed);
-
-    var instance = new Enhanced();
-
-    expect(instance.state).to.deep.equal({_radiumStyleState: {}});
-  });
-
-  it('merges with existing state', () => {
-    class Composed extends Component {
-      constructor () {
-        super();
-        this.state = {foo: 'bar'};
-      }
-    }
-    var Enhanced = Enhancer(Composed);
-
-    var instance = new Enhanced();
-
-
-    expect(instance.state).to.deep.equal(
-      {foo: 'bar', _radiumStyleState: {}}
-    );
-  });
-
   it('receives the given props', () => {
     class Composed extends Component {
       constructor (props) {


### PR DESCRIPTION
This also removes the setting up of the initial `this.state._radiumStyleState` because there's no way to reconcile the differences between ES6 classes and React.createClass without creating a wrapping constructor that kills hot loading. It also removes the tests for that behaviour because it doesn't actually seem to negatively affect the behaviour.

You can see that this branch works with hot loader by cloning my fork of `react-hot-boilerplate` - https://github.com/bobbyrenwick/react-hot-boilerplate/tree/test-radium-hoc.

The only thing I'm not too sure about is that I've deleted some Flow annotations and I'm not sure what sort of effects that will have as I haven't had much time to play around with it! @ianobermiller is there anything Flow related that needs to be done?

Fixes #219 