### PR TITLE
warn the displayName of component with shorthand / longhand mixing

### DIFF
--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -208,8 +208,9 @@ var resolveStyles = function (
             'Radium: property "' + shorthand + '" in style object',
             style,
             ': do not mix longhand and ' +
-            'shorthand properties in the same style object. See ' +
-            'https://github.com/FormidableLabs/radium/issues/95 for more ' +
+            'shorthand properties in the same style object. Check the render ' +
+            'method of ' + component.constructor.displayName + '.',
+            'See https://github.com/FormidableLabs/radium/issues/95 for more ' +
             'information.'
           );
           /* eslint-enable no-console */


### PR DESCRIPTION
This adds the `displayName` of the component that is mixing shorthand styles with longhand styles. This should make debugging the issue much quicker!