### PR TITLE
fixing React Hot Loader by copying methods across to top level prototype

### DIFF
--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -61,6 +61,16 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
     }
   });
 
+  if (process.env.NODE_ENV !== 'production') {
+    // This fixes React Hot Loader by exposing the original components top level
+    // prototype methods on the Radium enhanced prototype as discussed in #219.
+    Object.keys(ComposedComponent.prototype).forEach(key => {
+      if (!RadiumEnhancer.prototype.hasOwnProperty(key)) {
+        RadiumEnhancer.prototype[key] = ComposedComponent.prototype[key];
+      }
+    });
+  }
+
   RadiumEnhancer.displayName = `Radium(${displayName})`;
 
   return RadiumEnhancer;


### PR DESCRIPTION
Let's hope second time around I've actually solved this...

This is solution 2 from @gaearon's suggestions. #252 needs to be closed because I couldn't find any way to resolve https://github.com/facebook/react/issues/3316 and the differences between setting the state in ES6 classes vs `React.createClass` without doing something similar to the current master branch.

Given that the code was heading back in that direction, I opted for just exposing all methods on the Component's prototype that haven't already been overwritten by the subclass. I liked the suggestion of only doing this in dev too, so I've sorted that too.

Example of it here - https://github.com/bobbyrenwick/react-hot-boilerplate/tree/test-radium-hoc-2