### PR TITLE
Allow falsy style values

### DIFF
--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -902,7 +902,7 @@ describe('resolveStyles', function () {
       expect(console.warn).to.not.have.been.called;
     });
 
-    it('does not warn when passed a falsy entry value', function () {
+    it('does not throw when passed a falsy entry value', function () {
       var component = genComponent();
       var renderedElement = (
         <div style={{

--- a/modules/__tests__/resolve-styles-test.js
+++ b/modules/__tests__/resolve-styles-test.js
@@ -901,6 +901,19 @@ describe('resolveStyles', function () {
 
       expect(console.warn).to.not.have.been.called;
     });
+
+    it('does not warn when passed a falsy entry value', function () {
+      var component = genComponent();
+      var renderedElement = (
+        <div style={{
+          height: null
+        }} />
+      );
+
+      expect(function () {
+        resolveStyles(component, renderedElement);
+      }).to.not.throw();
+    });
   });
   /* eslint-enable no-console */
 });

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -281,7 +281,7 @@ var resolveStyles = function (
     };
 
     var checkProps = s => {
-      if (typeof s !== 'object') {
+      if (typeof s !== 'object' || !s) {
         return;
       }
 


### PR DESCRIPTION
The ability to do `<Component style={{ height: null }} />` was broken in #95. That behavior is useful in a few situations and this pull request should restore it.