### PR TITLE
Rewrite prefixMatch to use a for loop instead of Array prototype

### DIFF
--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -100,10 +100,17 @@ if (ExecutionEnvironment.canUseDOM) {
 
   // Based on http://davidwalsh.name/vendor-prefix
   var windowStyles = window.getComputedStyle(document.documentElement, '');
-  var prefixMatch = Array.prototype.slice.call(windowStyles)
-    .join('')
-    .match(/-(moz|webkit|ms|o)-/);
-  var cssVendorPrefix = prefixMatch && prefixMatch[0];
+  var prefixMatch, cssVendorPrefix;
+
+  for (var i = 0; i < windowStyles.length; i++) {
+    prefixMatch = windowStyles[i].match(/-(moz|webkit|ms|o)-/);
+
+    if (prefixMatch) {
+      break;
+    }
+  }
+
+  cssVendorPrefix = prefixMatch && prefixMatch[0];
 
   prefixInfo = infoByCssPrefix[cssVendorPrefix] || prefixInfo;
 }

--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -103,6 +103,9 @@ if (ExecutionEnvironment.canUseDOM) {
   var prefixMatch;
   var windowStyles = window.getComputedStyle(document.documentElement, '');
 
+  // Array.prototype.slice.call(windowStyles) fails with
+  // "Uncaught TypeError: undefined is not a function"
+  // in older versions Android (KitKat) web views
   for (var i = 0; i < windowStyles.length; i++) {
     prefixMatch = windowStyles[i].match(/-(moz|webkit|ms|o)-/);
 

--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -6,6 +6,8 @@
 var ExecutionEnvironment = require('exenv');
 var arrayFind = require('array-find');
 
+var VENDOR_PREFIX_REGEX = /-(moz|webkit|ms|o)-/;
+
 var infoByCssPrefix = {
   '-moz-': {
     cssPrefix: '-moz-',
@@ -95,6 +97,7 @@ var prefixInfo = {
   jsPrefix: ''
 };
 
+
 if (ExecutionEnvironment.canUseDOM) {
   domStyle = document.createElement('p').style;
 
@@ -107,7 +110,7 @@ if (ExecutionEnvironment.canUseDOM) {
   // "Uncaught TypeError: undefined is not a function"
   // in older versions Android (KitKat) web views
   for (var i = 0; i < windowStyles.length; i++) {
-    prefixMatch = windowStyles[i].match(/-(moz|webkit|ms|o)-/);
+    prefixMatch = windowStyles[i].match(VENDOR_PREFIX_REGEX);
 
     if (prefixMatch) {
       break;

--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -99,8 +99,9 @@ if (ExecutionEnvironment.canUseDOM) {
   domStyle = document.createElement('p').style;
 
   // Based on http://davidwalsh.name/vendor-prefix
+  var cssVendorPrefix;
+  var prefixMatch;
   var windowStyles = window.getComputedStyle(document.documentElement, '');
-  var prefixMatch, cssVendorPrefix;
 
   for (var i = 0; i < windowStyles.length; i++) {
     prefixMatch = windowStyles[i].match(/-(moz|webkit|ms|o)-/);


### PR DESCRIPTION
This is an extreme use case, but one that we encountered while testing our web app inside an Android web view (chromium).

Calling `Array.prototype.slice` with the `windowStyles` object causes an `Uncaught TypeError: undefined is not a function` in older versions Android (KitKat) web views. This rewrites it to use a for loop.

- `npm run lint` passed
- `npm test` passed
- `flow` returned a few errors in files unrelated to this PR

**Note:** I couldn't figure out *why* it was returning that error, but did confirm that it was that line causing the error. We monkey patched the module with this fix and it eliminated the error. Perhaps older versions of chromium don't support calling an Array prototype method with an Object?