### PR TITLE
Use ES2015 template strings instead of concatenation.

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -141,7 +141,7 @@ var pulseKeyframes = Radium.keyframes({
 
 var styles = {
   inner: {
-    animation: pulseKeyframes + ' 3s ease 0s infinite',
+    animation: `${pulseKeyframes} 3s ease 0s infinite`,
     background: 'blue',
     height: '4px',
     margin: '0 auto',


### PR DESCRIPTION
I personally find that template strings are more readable and look cleaner than string concatenation, and as long as we're using ES2015+ (classes and decorators and whatnot) I think this is a worthwhile change.