### PR TITLE
fix older firefox missing float property problem

### DIFF
--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -101,6 +101,12 @@ var prefixInfo = {
 if (ExecutionEnvironment.canUseDOM) {
   domStyle = document.createElement('p').style;
 
+  // older Firefox versions may have no float property in style object
+  // so we need to add it manually
+  if (domStyle.float === undefined) {
+    domStyle.float = "";
+  }
+
   // Based on http://davidwalsh.name/vendor-prefix
   var cssVendorPrefix;
   var prefixMatch;


### PR DESCRIPTION
For older Firefox(for our case, they're version 30 and 31), the element created by document will have no 'float' key for its style.
This caused malfunction in the UI because all float attributes were missing.

If this is the only case, then we propose a simple fix by adding a float attribute to domStyle.
Please correct me if there're better ways.
