### PR TITLE
Fix errors emitted by latest version of Flow

### DIFF
--- a/modules/config.js
+++ b/modules/config.js
@@ -12,7 +12,7 @@ module.exports = {
     return typeof _matchMediaFunction === 'function';
   },
 
-  matchMedia (query: string) {
+  matchMedia (query: string): Object {
     return _matchMediaFunction(query);
   },
 

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -4,7 +4,7 @@ var resolveStyles = require('./resolve-styles.js');
 
 var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
   class RadiumEnhancer extends ComposedComponent {
-    _radiumMediaQueryListenersByQuery: Object<string, {remove: () => void}>;
+    _radiumMediaQueryListenersByQuery: {[key: string]: {remove: () => void}};
     _radiumMouseUpListener: {remove: () => void};
 
     constructor () {

--- a/modules/get-state.js
+++ b/modules/get-state.js
@@ -5,7 +5,7 @@ var getStateKey = require('./get-state-key');
 var VALID_KEYS = [':active', ':focus', ':hover'];
 
 var getState = function (
-  state: {_radiumStyleState: Object<string, Object<string, boolean>>},
+  state: {_radiumStyleState: {[key: string]: {[key: string]: boolean}}},
   elementKey: string,
   value: string
 ): boolean {

--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -10,14 +10,13 @@ var isAnimationSupported = ExecutionEnvironment.canUseDOM &&
 
 var animationIndex = 1;
 var animationStyleSheet = null;
-var keyframesPrefixed = null;
+var keyframesPrefixed = 'keyframes';
 
 if (isAnimationSupported) {
   animationStyleSheet = (document.createElement('style'): any);
   document.head.appendChild(animationStyleSheet);
 
   // Test if prefix needed for keyframes (copied from PrefixFree)
-  keyframesPrefixed = 'keyframes';
   animationStyleSheet.textContent = '@keyframes {}';
   if (!animationStyleSheet.sheet.cssRules.length) {
     keyframesPrefixed = Prefixer.cssPrefix + 'keyframes';
@@ -27,7 +26,7 @@ if (isAnimationSupported) {
 // Simple animation helper that injects CSS into a style object containing the
 // keyframes, and returns a string with the generated animation name.
 var keyframes = function (
-  keyframeRules: Object<string, Object<string, string|number>>
+  keyframeRules: {[key: string]: {[key: string]: string|number}}
 ): string {
   var name = 'Animation' + animationIndex;
   animationIndex += 1;

--- a/modules/resolve-styles.js
+++ b/modules/resolve-styles.js
@@ -125,7 +125,7 @@ var _resolveMediaQueryStyles = function (component, style) {
 var resolveStyles = function (
   component: any, // ReactComponent, flow+eslint complaining
   renderedElement: any, // ReactElement
-  existingKeyMap?: Object<string, string>
+  existingKeyMap?: {[key: string]: boolean}
 ): any { // ReactElement
   existingKeyMap = existingKeyMap || {};
 


### PR DESCRIPTION
* Add missing return value annotation
* Migrate away from `Object<K, V>` syntax which is no longer supported
* Fix annotation of `existingKeyMap`, whose values are boolean (I think)
* Fix potential null + string error (`keyframesPrefixed`)

Unfortunately there is no way to specify which version of Flow we depend on, since it's not JS and exists outside of npm land.

Done in preparation for #270.