### PR TITLE
Prevents errors from getters that do not have setters.

### DIFF
--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -66,7 +66,8 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
     // prototype methods on the Radium enhanced prototype as discussed in #219.
     Object.keys(ComposedComponent.prototype).forEach(key => {
       if (!RadiumEnhancer.prototype.hasOwnProperty(key)) {
-        RadiumEnhancer.prototype[key] = ComposedComponent.prototype[key];
+        var descriptor = Object.getOwnPropertyDescriptor(ComposedComponent.prototype, key);
+        Object.defineProperty(RadiumEnhancer.prototype, key, descriptor);
       }
     });
   }


### PR DESCRIPTION
I'm using radium with material-ui which seems to be defining a getter without a setter. It causes this code to break. This is a much safer way to copy properties.