### PR TITLE
Update babel

### DIFF
--- a/modules/prefixer.js
+++ b/modules/prefixer.js
@@ -313,10 +313,7 @@ var _getPrefixedValue = function (component, property, value, originalProperty) 
 
   var cacheKey = Array.isArray(value) ? (
     value.join(' || ')
-  /* babel-eslint bug: https://github.com/babel/babel-eslint/issues/149 */
-  /* eslint-disable space-infix-ops */
   ) : (
-  /* eslint-enable space-infix-ops */
     property + value
   );
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "array-find": "^1.0.0",
     "exenv": "^1.2.0",
-    "babel": "^5.5.8",
+    "babel": "^5.8.21",
     "rimraf": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@sebmck has confirmed that the `babel-eslint` bug we were having to work around [has been fixed](https://github.com/babel/babel-eslint/issues/149#issuecomment-123403259) since `> 5.8.0` - perfect opportunity to bump us up to the latest version of `babel` and removing `eslint-disable space-infix-ops`.

Running the tests & linting seems to be all good after the update :+1: 