### PR TITLE
Copy all static props

### DIFF
--- a/modules/__tests__/enhancer-test.js
+++ b/modules/__tests__/enhancer-test.js
@@ -155,14 +155,16 @@ describe('Enhancer', () => {
     });
   });
 
-  it('manually populates static properties for IE <10', () => {
+  it('manually populates all static properties for IE <10', () => {
     class Composed extends Component { }
 
     Composed.defaultProps = { foo: 'bar' };
+    Composed.someOtherProp = { bar: 'foo' };
 
     var Enhanced = Enhancer(Composed);
 
     expect(Enhanced.defaultProps).to.deep.equal({ foo: 'bar' });
+    expect(Enhanced.someOtherProp).to.deep.equal({ bar: 'foo' });
   });
 
   it('copies methods across to top level prototype', () => {

--- a/modules/__tests__/enhancer-test.js
+++ b/modules/__tests__/enhancer-test.js
@@ -157,7 +157,7 @@ describe('Enhancer', () => {
 
   it('manually populates all static properties for IE <10', () => {
     class Composed extends Component {
-      static staticMethod() {
+      static staticMethod () {
         return { bar: 'foo' };
       }
     }

--- a/modules/__tests__/enhancer-test.js
+++ b/modules/__tests__/enhancer-test.js
@@ -156,15 +156,18 @@ describe('Enhancer', () => {
   });
 
   it('manually populates all static properties for IE <10', () => {
-    class Composed extends Component { }
+    class Composed extends Component {
+      static staticMethod() {
+        return { bar: 'foo' };
+      }
+    }
 
     Composed.defaultProps = { foo: 'bar' };
-    Composed.someOtherProp = { bar: 'foo' };
 
     var Enhanced = Enhancer(Composed);
 
     expect(Enhanced.defaultProps).to.deep.equal({ foo: 'bar' });
-    expect(Enhanced.someOtherProp).to.deep.equal({ bar: 'foo' });
+    expect(Enhanced.staticMethod()).to.deep.equal({ bar: 'foo' });
   });
 
   it('copies methods across to top level prototype', () => {

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -48,29 +48,14 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
   // with IE <10 any static properties of the superclass aren't inherited and
   // so need to be manually populated
   // See http://babeljs.io/docs/advanced/caveats/#classes-10-and-below-
-  var staticKeys = [
-    'defaultProps',
-    'propTypes',
-    'contextTypes',
-    'childContextTypes'
-  ];
-
-  staticKeys.forEach((key) => {
-    if (ComposedComponent.hasOwnProperty(key)) {
-      RadiumEnhancer[key] = ComposedComponent[key];
+  // This also fixes React Hot Loader by exposing the original components top level
+  // prototype methods on the Radium enhanced prototype as discussed in #219.
+  Object.keys(ComposedComponent.prototype).forEach(key => {
+    if (!RadiumEnhancer.prototype.hasOwnProperty(key)) {
+      var descriptor = Object.getOwnPropertyDescriptor(ComposedComponent.prototype, key);
+      Object.defineProperty(RadiumEnhancer.prototype, key, descriptor);
     }
   });
-
-  if (process.env.NODE_ENV !== 'production') {
-    // This fixes React Hot Loader by exposing the original components top level
-    // prototype methods on the Radium enhanced prototype as discussed in #219.
-    Object.keys(ComposedComponent.prototype).forEach(key => {
-      if (!RadiumEnhancer.prototype.hasOwnProperty(key)) {
-        var descriptor = Object.getOwnPropertyDescriptor(ComposedComponent.prototype, key);
-        Object.defineProperty(RadiumEnhancer.prototype, key, descriptor);
-      }
-    });
-  }
 
   RadiumEnhancer.displayName =
     ComposedComponent.displayName ||

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -50,7 +50,7 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
   // See http://babeljs.io/docs/advanced/caveats/#classes-10-and-below-
   // This also fixes React Hot Loader by exposing the original components top level
   // prototype methods on the Radium enhanced prototype as discussed in #219.
-  Object.keys(ComposedComponent.prototype).forEach(key => {
+  Object.getOwnPropertyNames(ComposedComponent.prototype).forEach(key => {
     if (!RadiumEnhancer.prototype.hasOwnProperty(key)) {
       var descriptor = Object.getOwnPropertyDescriptor(ComposedComponent.prototype, key);
       Object.defineProperty(RadiumEnhancer.prototype, key, descriptor);


### PR DESCRIPTION
Fixes bug with only copying a certain set of static properties - now all properties are copied.

Closes #313