### PR TITLE
Adding Travis e-mail notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ branches:
   only:
     - master
 
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+
 script:
   - npm run lint
   - npm run test-coverage


### PR DESCRIPTION
This adds e-mail notifications - always on failures & only when a change occurs for successes (so when something changes from failure to success).