### PR TITLE
getStateKey should return "main" when empty string is passed in

### DIFF
--- a/modules/get-state-key.js
+++ b/modules/get-state-key.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 var getStateKey = function (elementKey: ?string): string {
-  return elementKey === null || elementKey === undefined ?
+  return elementKey === null || elementKey === undefined || elementKey === '' ?
     'main' :
     elementKey.toString();
 };


### PR DESCRIPTION
Previously an empty string key would result in 'main'.  Functionality changed in this commit: https://github.com/FormidableLabs/radium/pull/287