### PR TITLE
Fixing bug where no static properties were copied over in IE < 10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ test_script:
   - node --version
   - node_modules\.bin\npm --version
   # run tests
-  - node_modules\.bin\npm test
+  - node_modules\.bin\npm run test-ie
 
 # Don't actually build.
 build: off

--- a/karma.conf.ie.js
+++ b/karma.conf.ie.js
@@ -2,9 +2,9 @@ module.exports = function (config) {
   require('./karma.conf.js')(config);
   config.set({
     plugins: config.plugins.concat('karma-ie-launcher'),
-    browsers: ['IE'],
+    browsers: ['IE9'],
     customLaunchers: {
-      IE11: {
+      IE9: {
         base: 'IE',
         'x-ua-compatible': 'IE=EmulateIE9'
       }

--- a/karma.conf.ie.js
+++ b/karma.conf.ie.js
@@ -1,0 +1,13 @@
+module.exports = function (config) {
+  require('./karma.conf.js')(config);
+  config.set({
+    plugins: config.plugins.concat('karma-ie-launcher'),
+    browsers: ['IE'],
+    customLaunchers: {
+      IE11: {
+        base: 'IE',
+        'x-ua-compatible': 'IE=EmulateIE9'
+      }
+    }
+  });
+};

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -56,8 +56,7 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
 
   // Class inheritance uses Object.create and because of __proto__ issues
   // with IE <10 any static properties of the superclass aren't inherited and
-  // so need to be manually populated. We only want to go over that object's
-  // non-enumerable properties, so use Object.keys.
+  // so need to be manually populated.
   // See http://babeljs.io/docs/advanced/caveats/#classes-10-and-below-
   copyProperties(ComposedComponent, RadiumEnhancer);
 

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -46,8 +46,16 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
 
   // Class inheritance uses Object.create and because of __proto__ issues
   // with IE <10 any static properties of the superclass aren't inherited and
-  // so need to be manually populated
+  // so need to be manually populated. We only want to go over that object's
+  // non-enumerable properties, so use Object.keys.
   // See http://babeljs.io/docs/advanced/caveats/#classes-10-and-below-
+  Object.keys(ComposedComponent).forEach(key => {
+    if (!RadiumEnhancer.hasOwnProperty(key)) {
+      var descriptor = Object.getOwnPropertyDescriptor(ComposedComponent, key);
+      Object.defineProperty(RadiumEnhancer, key, descriptor);
+    }
+  });
+
   // This also fixes React Hot Loader by exposing the original components top level
   // prototype methods on the Radium enhanced prototype as discussed in #219.
   Object.getOwnPropertyNames(ComposedComponent.prototype).forEach(key => {

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -5,7 +5,7 @@ var printStyles = require('./print-styles.js');
 
 var copyProperties = function (source, target) {
   Object.getOwnPropertyNames(source).forEach(key => {
-    const ignoreKeys = ['type', 'arguments', 'callee', 'caller', 'length', 'name', 'prototype'];
+    var ignoreKeys = ['type', 'arguments', 'callee', 'caller', 'length', 'name', 'prototype'];
     if (ignoreKeys.indexOf(key) < 0 && !target.hasOwnProperty(key)) {
       var descriptor = Object.getOwnPropertyDescriptor(source, key);
       Object.defineProperty(target, key, descriptor);

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -60,9 +60,11 @@ var enhanceWithRadium = function (ComposedComponent: constructor): constructor {
   // See http://babeljs.io/docs/advanced/caveats/#classes-10-and-below-
   copyProperties(ComposedComponent, RadiumEnhancer);
 
-  // This also fixes React Hot Loader by exposing the original components top level
-  // prototype methods on the Radium enhanced prototype as discussed in #219.
-  copyProperties(ComposedComponent.prototype, RadiumEnhancer.prototype);
+  if (process.env.NODE_ENV !== 'production') {
+    // This also fixes React Hot Loader by exposing the original components top level
+    // prototype methods on the Radium enhanced prototype as discussed in #219.
+    copyProperties(ComposedComponent.prototype, RadiumEnhancer.prototype);
+  }
 
   RadiumEnhancer.displayName =
     ComposedComponent.displayName ||

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepublish": "npm test && npm run lint && npm run lib",
     "test": "karma start",
     "test-coverage": "karma start karma.conf.coverage.js",
+    "test-ie": "karma start karma.conf.ie.js",
     "test-dev": "karma start --no-single-run --auto-watch"
   },
   "license": "MIT",
@@ -43,6 +44,7 @@
     "karma": "^0.13.3",
     "karma-babel-preprocessor": "^5.2.1",
     "karma-coverage": "^0.4.2",
+    "karma-ie-launcher": "^0.2.0",
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.0.2",
     "karma-phantomjs-launcher": "^0.2.0",


### PR DESCRIPTION
This one again. It seems the implementation in #316 actually stops any static properties being copied over in IE < 10 (@AnSavvides). This had the unfortunate side effect of breaking our app in IE for a few days.

The reasons the tests don't catch it are because we only run the tests in PhantomJS so the bugs that exist in IE < 10 don't materialise. I've changed AppVeyor to use [karma-ie-launcher](https://github.com/karma-runner/karma-ie-launcher) and made IE11 run in IE9 compatibility mode in order to catch the bug. You can see it [catches the bug](https://ci.appveyor.com/project/bobbyrenwick/radium/build/1.0.4/job/x3j8dtfiqr789xfv) on a test run of a branch without this fix in.

