### PR TITLE
Removing dead code

### DIFF
--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -29,6 +29,12 @@ var keyframes = function (
   keyframeRules: {[percentage: string]: {[key: string]: string|number}},
   componentName?: string
 ): string {
+  // for flow
+  /* istanbul ignore next */
+  if (!animationStyleSheet) {
+    throw new Error('keyframes not initialized properly');
+  }
+
   var name = 'Animation' + animationIndex;
   animationIndex += 1;
 

--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -45,12 +45,6 @@ var keyframes = function (
     }).join('\n') +
     '\n}\n';
 
-  // for flow
-  /* istanbul ignore next */
-  if (!animationStyleSheet) {
-    throw new Error('keyframes not initialized properly');
-  }
-
   animationStyleSheet.sheet.insertRule(
     rule,
     animationStyleSheet.sheet.cssRules.length

--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -29,17 +29,17 @@ var keyframes = function (
   keyframeRules: {[percentage: string]: {[key: string]: string|number}},
   componentName?: string
 ): string {
-  // for flow
-  /* istanbul ignore next */
-  if (!animationStyleSheet) {
-    throw new Error('keyframes not initialized properly');
-  }
-
   var name = 'Animation' + animationIndex;
   animationIndex += 1;
 
   if (!isAnimationSupported) {
     return name;
+  }
+
+  // for flow
+  /* istanbul ignore next */
+  if (!animationStyleSheet) {
+    throw new Error('keyframes not initialized properly');
   }
 
   var rule = '@' + keyframesPrefixed + ' ' + name + ' {\n' +


### PR DESCRIPTION
As far as I can tell - correct me if I am wrong - this was just dead code.

To begin with, `animationStyleSheet` is set to be `null` and this changes when `isAnimationSupported` is `true` -- within the `keyframes` function, we do the following check:

```js
if (!isAnimationSupported) {
  return name;
}
```

...which happens before the (now removed) `throw`. Therefore, `animationStyleSheet` could never not be `truthy` at this point if `isAnimationSupported` is `true`. If `isAnimationSupported` were `true` and `animationStyleSheet` was to be `null` or a `false`-y value (for whatever reason), it would break here anyway, before ever getting to the `throw` portion of the code:

```js
animationStyleSheet.textContent = '@keyframes {}';
```

We could add a check before the above and if `animationStyleSheet` is `false`-y we could `throw` an `Error`, otherwise proceed?