### PR TITLE
When hovering, remove :hover from the previous hovered component

### DIFF
--- a/modules/plugins/resolve-interaction-styles-plugin.js
+++ b/modules/plugins/resolve-interaction-styles-plugin.js
@@ -10,6 +10,8 @@ var _isInteractiveStyleField = function (styleFieldName) {
     styleFieldName === ':focus';
 };
 
+var lastHover;
+
 var resolveInteractionStyles = function (config: PluginConfig): PluginResult {
   var {
     ExecutionEnvironment,
@@ -32,7 +34,11 @@ var resolveInteractionStyles = function (config: PluginConfig): PluginResult {
     var existingOnMouseEnter = props.onMouseEnter;
     newProps.onMouseEnter = function (e) {
       existingOnMouseEnter && existingOnMouseEnter(e);
+      if (lastHover) {
+        lastHover.setState(':hover', false);
+      }
       setState(':hover', true);
+      lastHover = config;
     };
 
     var existingOnMouseLeave = props.onMouseLeave;


### PR DESCRIPTION
Fixes #367 

I haven't written tests around this, as I'm not sure you will accept it due to the (admittedly ugly!) global state. 

However, this has solved my problem, when running it locally. 

If this is accepted in theory, I'll make it ready for pulling!