### PR TITLE
Allow replacing prefixer in keyframes and <Style/>

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -222,9 +222,9 @@ function ConfiguredRadium(component) {
 class MyComponent extends React.Component { ... }
 ```
 
-You will typically want to put plugins before the final `checkProps` so that you can still benefit from the checks it provides. If your plugin might produce other pseudo-style blocks, like `@media` consumed by `resolveMediaQueries` or `:hover` consumed by `resolveInteractionStyles`, you would want to have your plugin run before those plugins. 
+You will typically want to put plugins before the final `checkProps` so that you can still benefit from the checks it provides. If your plugin might produce other pseudo-style blocks, like `@media` consumed by `resolveMediaQueries` or `:hover` consumed by `resolveInteractionStyles`, you would want to have your plugin run before those plugins.
 
-You can of course omit any or all of the built-in plugins, and replace them with your own version. For example, you may want to omit `Radium.Plugins.prefix` entirely if you aren't using vendor prefixes or are using a [compile-time solution](https://github.com/UXtemple/babel-plugin-react-autoprefix) instead. 
+You can of course omit any or all of the built-in plugins, and replace them with your own version. For example, you may want to omit `Radium.Plugins.prefix` entirely if you aren't using vendor prefixes or are using a [compile-time solution](https://github.com/UXtemple/babel-plugin-react-autoprefix) instead.
 
 ## getState
 
@@ -249,11 +249,13 @@ Usage:
 
 ## keyframes
 
-**Radium.keyframes(keyframes, componentName)**
+**Radium.keyframes(keyframes, [componentName], [prefixFunction])**
 
 Create a keyframes animation for use in any inline style. `keyframes` is a helper that translates the keyframes object you pass in to CSS and injects the `@keyframes` (prefixed properly) definition into a style sheet. Automatically generates and returns a name for the keyframes, that you can then use in the value for `animation`. Radium will automatically apply vendor prefixing to keyframe styles.
 
-`Radium.keyframes` takes a second optional parameter, `componentName`. This is optional as you may not always have a component name to pass. If you do have a `componentName` however, it is a good idea to pass that as a parameter for better warning & error reporting.
+`Radium.keyframes` takes an optional second parameter, `componentName`. This is optional as you may not always have a component name to pass. If you do have a `componentName` however, it is a good idea to pass that as a parameter for better warning & error reporting.
+
+`Radium.keyframes` takes an optional third parameter, `prefixFunction`. `prefixFunction` replaces the built-in prefixer with a function of your own. `prefixFunction` is called with two arguments, the `styles` object, and the `componentName`, e.g. `prefixFunction(styles, componentName)`.
 
 ```as
 @Radium
@@ -285,7 +287,7 @@ var styles = {
 
 ## Plugins
 
-### Built-ins
+### Built-in Plugins
 
 Almost everything that Radium does, except iteration, is implemented as a plugin. Radium ships with a base set of plugins, all of which can be accessed via `Radium.Plugins.pluginName`. They are called in the following order:
 
@@ -434,6 +436,10 @@ A string that any included selectors in `rules` will be appended to. Use to scop
   />
 </div>
 ```
+
+#### prefix
+
+Optional prop to replace the built-in prefixer with a function of your own. `prefix` is called with two arguments, the `styles` object, and the `componentName`, e.g. `prefix(styles, componentName)`.
 
 ## PrintStyleSheet component
 

--- a/modules/__mocks__/prefixer.js
+++ b/modules/__mocks__/prefixer.js
@@ -1,17 +1,3 @@
-var nextPrefixedPropertyName = null;
-
 module.exports = {
-  getPrefixedPropertyName: name => {
-    if (nextPrefixedPropertyName !== null) {
-      name = nextPrefixedPropertyName;
-      nextPrefixedPropertyName = null;
-    }
-    return name;
-  },
-  getPrefixedStyle: (component, style) => style,
-  cssPrefix: '-webkit-',
-
-  __setNextPrefixedPropertyName (name) {
-    nextPrefixedPropertyName = name;
-  }
+  getPrefixedStyle: style => style
 };

--- a/modules/__tests__/prefixer-test.js
+++ b/modules/__tests__/prefixer-test.js
@@ -61,7 +61,7 @@ describe('Prefixer', () => {
     };
 
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    var result = Prefixer.getPrefixedStyle('MyComponent', {display: 'flex'});
+    var result = Prefixer.getPrefixedStyle({display: 'flex'});
 
     expect(result).to.deep.equal({display: 'flex'});
     expect(Prefixer.cssPrefix).to.equal('');
@@ -75,7 +75,7 @@ describe('Prefixer', () => {
     mockStyle = { transform: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle('MyComponent', {transform: 'foo'})).to.deep.equal({transform: 'foo'}
+      Prefixer.getPrefixedStyle({transform: 'foo'})).to.deep.equal({transform: 'foo'}
     );
   });
 
@@ -87,15 +87,15 @@ describe('Prefixer', () => {
       set transform (value) { }
     };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    Prefixer.getPrefixedStyle('MyComponent', {transform: 'foo'});
-    Prefixer.getPrefixedStyle('MyComponent', {transform: 'foo'});
+    Prefixer.getPrefixedStyle({transform: 'foo'});
+    Prefixer.getPrefixedStyle({transform: 'foo'});
     expect(transformGetter).to.have.been.calledOnce;
   });
 
   it('ignores property if not in style object', () => {
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     mockStyle = {};
-    expect(Prefixer.getPrefixedStyle('MyComponent', {transform: 'foo'})).to.deep.equal({});
+    expect(Prefixer.getPrefixedStyle({transform: 'foo'})).to.deep.equal({});
   });
 
   it('uses prefixed property if unprefixed not in style object', () => {
@@ -103,9 +103,7 @@ describe('Prefixer', () => {
     mockStyle = { WebkitTransform: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {transform: 'foo'}
-      )
+      Prefixer.getPrefixedStyle({transform: 'foo'})
     ).to.deep.equal({WebkitTransform: 'foo'});
   });
 
@@ -114,9 +112,7 @@ describe('Prefixer', () => {
     mockStyle = { MozBoxFlex: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {flex: 1}
-      )
+      Prefixer.getPrefixedStyle({flex: 1})
     ).to.deep.equal({MozBoxFlex: 1});
   });
 
@@ -125,9 +121,7 @@ describe('Prefixer', () => {
     mockStyle = { MozBoxFlex: '1', lineHeight: 2 };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {MozBoxFlex: 1, lineHeight: 2}
-      )
+      Prefixer.getPrefixedStyle({MozBoxFlex: 1, lineHeight: 2})
     ).to.deep.equal({MozBoxFlex: 1, lineHeight: 2});
   });
 
@@ -139,9 +133,7 @@ describe('Prefixer', () => {
     };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {transform: 'foo'}
-      )
+      Prefixer.getPrefixedStyle({transform: 'foo'})
     ).to.deep.equal({WebkitTransform: 'foo'});
   });
 
@@ -150,9 +142,7 @@ describe('Prefixer', () => {
     mockStyle = { transform: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {transform: 'foo'}
-      )
+      Prefixer.getPrefixedStyle({transform: 'foo'})
     ).to.deep.equal({transform: 'foo'});
   });
 
@@ -164,9 +154,7 @@ describe('Prefixer', () => {
     };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {transform: 'foo'}
-      )
+      Prefixer.getPrefixedStyle({transform: 'foo'})
     ).to.deep.equal({transform: 'foo'});
   });
 
@@ -174,9 +162,7 @@ describe('Prefixer', () => {
     mockStyle = { lineHeight: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {lineHeight: 2}
-      )
+      Prefixer.getPrefixedStyle({lineHeight: 2})
     ).to.deep.equal({lineHeight: 2});
   });
 
@@ -184,9 +170,7 @@ describe('Prefixer', () => {
     mockStyle = { lineHeight: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {lineHeight: '2em'}
-      )
+      Prefixer.getPrefixedStyle({lineHeight: '2em'})
     ).to.deep.equal({lineHeight: '2em'});
   });
 
@@ -194,8 +178,7 @@ describe('Prefixer', () => {
     mockStyle = { lineHeight: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle('MyComponent', {lineHeight: null}
-      )
+      Prefixer.getPrefixedStyle({lineHeight: null})
     ).to.deep.equal({lineHeight: null});
   });
 
@@ -203,9 +186,7 @@ describe('Prefixer', () => {
     mockStyle = { lineHeight: '' };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {lineHeight: undefined}
-      )
+      Prefixer.getPrefixedStyle({lineHeight: undefined})
     ).to.deep.equal({lineHeight: undefined}
     );
   });
@@ -225,9 +206,7 @@ describe('Prefixer', () => {
     };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {display: 'flex'}
-      )
+      Prefixer.getPrefixedStyle({display: 'flex'})
     ).to.deep.equal({display: '-webkit-flex'});
   });
 
@@ -246,9 +225,7 @@ describe('Prefixer', () => {
     };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle(
-        'MyComponent', {display: 'flex'}
-      )
+      Prefixer.getPrefixedStyle({display: 'flex'})
     ).to.deep.equal({display: '-webkit-box'});
   });
 
@@ -267,7 +244,7 @@ describe('Prefixer', () => {
     };
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle('MyComponent', {color: ['rgba(255, 255, 255, .5)', '#fff']})
+      Prefixer.getPrefixedStyle({color: ['rgba(255, 255, 255, .5)', '#fff']})
     ).to.deep.equal({color: '#fff'});
   });
 
@@ -275,30 +252,30 @@ describe('Prefixer', () => {
     mockStyle = {height: 'auto'};
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle('MyComponent', {height: [400, 'calc(100vh - 100px)']})
+      Prefixer.getPrefixedStyle({height: [400, 'calc(100vh - 100px)']})
     ).to.deep.equal({height: '400px'});
     expect(
-      Prefixer.getPrefixedStyle('MyComponent', {height: ['500px', 'calc(100vh - 100px)']})
+      Prefixer.getPrefixedStyle({height: ['500px', 'calc(100vh - 100px)']})
     ).to.deep.equal({height: '500px'});
   });
 
   it('adds px to properties requiring units', () => {
     mockStyle = {height: 'auto'};
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle('MyComponent', {height: 400}))
+    expect(Prefixer.getPrefixedStyle({height: 400}))
       .to.deep.equal({height: '400px'});
   });
 
   it('doesn\'t add px to properties requiring units if value is 0', () => {
     mockStyle = {height: 'auto'};
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle('MyComponent', {height: 0})).to.deep.equal({height: 0});
+    expect(Prefixer.getPrefixedStyle({height: 0})).to.deep.equal({height: 0});
   });
 
   it('doesn\'t add px to properties not requiring units', () => {
     mockStyle = {zoom: '0'};
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle('MyComponent', {zoom: 4})).to.deep.equal({zoom: 4});
+    expect(Prefixer.getPrefixedStyle({zoom: 4})).to.deep.equal({zoom: 4});
   });
 
   it('converts non-strings to strings', () => {
@@ -309,30 +286,8 @@ describe('Prefixer', () => {
         return 'white';
       }
     };
-    expect(Prefixer.getPrefixedStyle('MyComponent', {color: colorHelper}))
+    expect(Prefixer.getPrefixedStyle({color: colorHelper}))
       .to.deep.equal({color: 'white'});
-  });
-
-  it('uses dash-case if mode is css', () => {
-    mockStyle = {
-      borderWidth: '1px'
-    };
-    var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle('MyComponent', {borderWidth: '1px'}, 'css')).to.deep.equal(
-      {'border-width': '1px'}
-    );
-  });
-
-  it('uses dash-case if mode is css and in server', () => {
-    exenv = {
-      canUseDOM: false,
-      canUseEventListeners: false
-    };
-
-    var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle('MyComponent', {borderWidth: '1px'}, 'css')).to.deep.equal(
-      {'border-width': '1px'}
-    );
   });
 
   it('uses first value in fallback array if in server', () => {
@@ -343,19 +298,8 @@ describe('Prefixer', () => {
 
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
     expect(
-      Prefixer.getPrefixedStyle('MyComponent', {color: ['rgba(255, 255, 255, .5)', '#fff']})
+      Prefixer.getPrefixedStyle({color: ['rgba(255, 255, 255, .5)', '#fff']})
     ).to.deep.equal({color: 'rgba(255, 255, 255, .5)'});
-  });
-
-  it('uses dash-prefix if mode is css', () => {
-    browserPrefix = '-webkit-';
-    mockStyle = {
-      WebkitBorderWidth: ''
-    };
-    var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle('MyComponent', {borderWidth: '1px'}, 'css')).to.deep.equal(
-      {'-webkit-border-width': '1px'}
-    );
   });
 
   /* eslint-disable no-console */
@@ -366,10 +310,10 @@ describe('Prefixer', () => {
 
     sinon.stub(console, 'warn');
     var Prefixer = require('inject!prefixer.js')({'exenv': exenv});
-    expect(Prefixer.getPrefixedStyle('MyComponent', {height: null})).to.deep.equal(
+    expect(Prefixer.getPrefixedStyle({height: null})).to.deep.equal(
       {height: null}
     );
-    expect(Prefixer.getPrefixedStyle('MyComponent', {height: undefined})).to.deep.equal(
+    expect(Prefixer.getPrefixedStyle({height: undefined})).to.deep.equal(
       {height: undefined}
     );
     expect(console.warn).not.to.have.been.called;

--- a/modules/camel-case-props-to-dash-case.js
+++ b/modules/camel-case-props-to-dash-case.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+var _camelCaseRegex = /([a-z])?([A-Z])/g;
+var _camelCaseReplacer = function (match, p1, p2) {
+  return p1 + '-' + p2.toLowerCase();
+};
+var _camelCaseToDashCase = function (s) {
+  return s.replace(_camelCaseRegex, _camelCaseReplacer);
+};
+
+var camelCasePropsToDashCase = function (prefixedStyle: Object): Object {
+  // Since prefix is expected to work on inline style objects, we must
+  // translate the keys to dash case for rendering to CSS.
+  return Object.keys(prefixedStyle).reduce((result, key) => {
+    result[_camelCaseToDashCase(key)] = prefixedStyle[key];
+    return result;
+  }, {});
+};
+
+module.exports = camelCasePropsToDashCase;

--- a/modules/keyframes.js
+++ b/modules/keyframes.js
@@ -1,33 +1,48 @@
 /* @flow */
 
+var camelCasePropsToDashCase = require('./camel-case-props-to-dash-case');
 var createMarkupForStyles = require('./create-markup-for-styles');
 var Prefixer = require('./prefixer');
 
 var ExecutionEnvironment = require('exenv');
 
-var isAnimationSupported = ExecutionEnvironment.canUseDOM &&
-  Prefixer.getPrefixedPropertyName('animation') !== false;
+var isAnimationSupported = false;
+var keyframesPrefixed = 'keyframes';
+
+if (ExecutionEnvironment.canUseDOM) {
+  // Animation feature detection and keyframes prefixing from MDN:
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Detecting_CSS_animation_support
+  var domPrefixes = ['Webkit', 'Moz', 'O', 'ms'];
+  var element = (document.createElement('div'): any);
+
+  if (element.style.animationName !== undefined) {
+    isAnimationSupported = true;
+  } else {
+    domPrefixes.some(function (prefix) {
+      if (element.style[prefix + 'AnimationName'] !== undefined) {
+        keyframesPrefixed = '-' + prefix.toLowerCase() + '-keyframes';
+        isAnimationSupported = true;
+        return true;
+      }
+      return false;
+    });
+  }
+}
 
 var animationIndex = 1;
 var animationStyleSheet = null;
-var keyframesPrefixed = 'keyframes';
 
 if (isAnimationSupported) {
   animationStyleSheet = (document.createElement('style'): any);
   document.head.appendChild(animationStyleSheet);
-
-  // Test if prefix needed for keyframes (copied from PrefixFree)
-  animationStyleSheet.textContent = '@keyframes {}';
-  if (!animationStyleSheet.sheet.cssRules.length) {
-    keyframesPrefixed = Prefixer.cssPrefix + 'keyframes';
-  }
 }
 
 // Simple animation helper that injects CSS into a style object containing the
 // keyframes, and returns a string with the generated animation name.
 var keyframes = function (
   keyframeRules: {[percentage: string]: {[key: string]: string|number}},
-  componentName?: string
+  componentName?: string,
+  prefix: (style: Object, componentName: ?string) => Object = Prefixer.getPrefixedStyle
 ): string {
   var name = 'Animation' + animationIndex;
   animationIndex += 1;
@@ -39,8 +54,9 @@ var keyframes = function (
   var rule = '@' + keyframesPrefixed + ' ' + name + ' {\n' +
     Object.keys(keyframeRules).map(function (percentage) {
       var props = keyframeRules[percentage];
-      var prefixedProps = Prefixer.getPrefixedStyle(componentName, props, 'css');
-      var serializedProps = createMarkupForStyles(prefixedProps, '  ');
+      var prefixedProps = prefix(props, componentName);
+      var cssPrefixedProps = camelCasePropsToDashCase(prefixedProps);
+      var serializedProps = createMarkupForStyles(cssPrefixedProps, '  ');
       return '  ' + percentage + ' {\n  ' + serializedProps + '\n  }';
     }).join('\n') +
     '\n}\n';

--- a/modules/plugins/prefix-plugin.js
+++ b/modules/plugins/prefix-plugin.js
@@ -7,7 +7,7 @@ var Prefixer = require('../prefixer');
 var prefixPlugin = function (
   {componentName, style}: PluginConfig
 ): PluginResult {
-  var newStyle = Prefixer.getPrefixedStyle(componentName, style);
+  var newStyle = Prefixer.getPrefixedStyle(style, componentName);
   return {style: newStyle};
 };
 


### PR DESCRIPTION
- Keyframes gets its own feature detection and prefixing from MDN
- Prefixer can be simplified, since both keyframes and Style do the
dash case conversion themselves