### PR TITLE
Add support for context in stateless components

### DIFF
--- a/modules/__tests__/radium-test.js
+++ b/modules/__tests__/radium-test.js
@@ -655,4 +655,44 @@ describe('Radium blackbox tests', () => {
 
     expect(div.style.color).to.equal('red');
   });
+
+  it('works with stateless components with context', () => {
+    let MyStatelessComponent = (props, context) => (
+      <div style={{color: 'blue', ':hover': {color: context.hoverColor}}}>
+        {props.children}
+      </div>
+    );
+    MyStatelessComponent.contextTypes = {
+      hoverColor: PropTypes.string
+    };
+    MyStatelessComponent = Radium(MyStatelessComponent);
+
+    class ContextGivingWrapper extends Component {
+      getChildContext () {
+        return {
+          hoverColor: 'green'
+        };
+      }
+      render () {
+        return this.props.children;
+      }
+    }
+    ContextGivingWrapper.childContextTypes = {
+      hoverColor: PropTypes.string
+    };
+
+    var output = TestUtils.renderIntoDocument(
+      <ContextGivingWrapper>
+        <MyStatelessComponent>hello world</MyStatelessComponent>
+      </ContextGivingWrapper>
+    );
+    var div = getElement(output, 'div');
+
+    expect(div.style.color).to.equal('blue');
+    expect(div.innerText).to.equal('hello world');
+
+    TestUtils.SimulateNative.mouseOver(div);
+
+    expect(div.style.color).to.equal('green');
+  });
 });

--- a/modules/enhancer.js
+++ b/modules/enhancer.js
@@ -46,10 +46,11 @@ var enhanceWithRadium = function (
   if (!ComposedComponent.render && !ComposedComponent.prototype.render) {
     ComposedComponent = class extends Component {
       render () {
-        return component(this.props);
+        return component(this.props, this.context);
       }
     };
     ComposedComponent.displayName = component.displayName || component.name;
+    ComposedComponent.contextTypes = component.contextTypes;
   }
 
   class RadiumEnhancer extends ComposedComponent {


### PR DESCRIPTION
Found a bug where Radium doesn't provide context for stateless components. This should fix it! :smiley: 

Pretty sure I ran all the necessary checks, but flow was acting up a bit for me. Happy to make any necessary changes.