### PR TITLE
Keyframes Server Side Rendering

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -20,3 +20,6 @@ src
 
 [libs]
 interfaces
+
+[options]
+suppress_comment= \\(.\\|\n\\)*\\$FlowStaticPropertyWarning

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -166,7 +166,7 @@ var App = React.createClass({
     );
   }
 });
-App = Radium(App);
+App = Radium({isRoot: true})(App);
 
 var squareStyles = {
   both: {
@@ -203,15 +203,16 @@ var tileStyle = {
   }
 };
 
-var pulseKeyframes = Radium.keyframes({
+var pulseAnimation = Radium.keyframes({
   '0%': {width: '10%'},
   '50%': {width: '50%'},
   '100%': {width: '10%'},
-}, Spinner);
+}, 'pulse');
 
 var spinnerStyles = {
   inner: {
-    animation: pulseKeyframes + ' 3s ease 0s infinite',
+    animation: 'x 3s ease 0s infinite',
+    animationName: pulseAnimation,
     background: 'blue',
     height: '4px',
     margin: '0 auto',

--- a/src/__tests__/keyframes-test.js
+++ b/src/__tests__/keyframes-test.js
@@ -2,7 +2,7 @@
 
 import Radium, {keyframes} from 'index';
 import {getElement} from 'test-helpers';
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
 import TestUtils from 'react-addons-test-utils';
 
 describe('keyframes', () => {
@@ -10,7 +10,7 @@ describe('keyframes', () => {
   it('renders keyframes in root style component', () => {
     const animation = keyframes({
       from: {left: '-1000px'},
-      to: {left: 0},
+      to: {left: 0}
     }, 'SlideFromLeft');
 
     @Radium({isRoot: true})
@@ -40,7 +40,7 @@ to{
   it('renders keyframes from child component', () => {
     const animation = keyframes({
       from: {left: '-1000px'},
-      to: {left: 0},
+      to: {left: 0}
     }, 'SlideFromLeft');
 
     @Radium()

--- a/src/__tests__/keyframes-test.js
+++ b/src/__tests__/keyframes-test.js
@@ -1,202 +1,81 @@
-let styleElement;
-let exenv;
-let sandbox;
+/* eslint-disable react/prop-types */
+
+import Radium, {keyframes} from 'index';
+import {getElement} from 'test-helpers';
+import React, {Component, PropTypes} from 'react';
+import TestUtils from 'react-addons-test-utils';
 
 describe('keyframes', () => {
 
-  beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    styleElement = {
-      textContent: '',
-      sheet: {
-        insertRule: sinon.spy(),
-        cssRules: []
-      },
-      style: {WebkitAnimationName: ''}
-    };
+  it('renders keyframes in root style component', () => {
+    const animation = keyframes({
+      from: {left: '-1000px'},
+      to: {left: 0},
+    }, 'SlideFromLeft');
 
-    [].slice.call(document.head.querySelectorAll('style')).forEach(node => {
-      document.head.removeChild(node);
-    });
+    @Radium({isRoot: true})
+    class TestComponent extends Component {
+      render() {
+        return <div style={{animationName: animation}} />;
+      }
+    }
 
-    exenv = {
-      canUseDOM: true,
-      canUseEventListeners: true
-    };
+    const output = TestUtils.renderIntoDocument(<TestComponent />);
 
-  });
+    const style = getElement(output, 'style');
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it('doesn\'t touch the DOM if DOM not available', () => {
-    sandbox.stub(document, 'createElement', () => {
-      return styleElement;
-    });
-
-    sandbox.stub(document.head, 'appendChild');
-
-    exenv = {
-      canUseDOM: false,
-      canUseEventListeners: false
-    };
-
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-
-    expect(document.createElement).not.to.have.been.called;
-    expect(document.head.appendChild).not.to.have.been.called;
-
-    const name = keyframes({}, 'MyComponent');
-
-    expect(name.length).to.be.greaterThan(0);
-  });
-
-  it('doesn\'t touch the DOM if animation not supported (IE9)', () => {
-    sandbox.stub(document, 'createElement', () => ({style: {}}));
-
-    sandbox.stub(document.head, 'appendChild');
-
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-
-    expect(document.head.appendChild).not.to.have.been.called;
-
-    const name = keyframes({}, 'MyComponent');
-
-    expect(name.length).to.be.greaterThan(0);
-  });
-
-  it('returns the expected name for the keyframes on first call', () => {
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-
-    const name = keyframes({}, 'MyComponent');
-
-    expect(name).to.equal('-radium-animation-0-1');
-  });
-
-  it('returns the expected name for the keyframes on second call', () => {
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-
-    keyframes({}, 'MyComponent');
-    const name2 = keyframes({}, 'MyComponent');
-
-    expect(name2).to.equal('-radium-animation-0-2');
-  });
-
-  it('returns the expected name for the keyframes on first call if a style sheet exists', () => {
-    document.head.appendChild(document.createElement('style'));
-
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-
-    const name = keyframes({}, 'MyComponent');
-
-    expect(name).to.equal('-radium-animation-1-1');
-  });
-
-  it('returns the expected name for the keyframes on second call if two style sheets exist', () => {
-    document.head.appendChild(document.createElement('style'));
-    document.head.appendChild(document.createElement('style'));
-
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-
-    keyframes({}, 'MyComponent');
-    const name2 = keyframes({}, 'MyComponent');
-
-    expect(name2).to.equal('-radium-animation-2-2');
-  });
-
-  it('does not always require a component', () => {
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-    const name = keyframes({});
-    expect(name.length).to.be.greaterThan(0);
-  });
-
-  it('prefixes @keyframes if needed', () => {
-    sandbox.stub(document, 'createElement', () => {
-      return styleElement;
-    });
-
-    sandbox.stub(document.head, 'appendChild');
-
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-    const name = keyframes({}, 'MyComponent');
-
-    expect(styleElement.sheet.insertRule.lastCall.args).to.deep.equal([
-      '@-webkit-keyframes ' + name + ' {\n\n}\n',
-      0
-    ]);
-  });
-
-  it('doesn\'t prefix @keyframes if not needed', () => {
-    sandbox.restore();
-    sandbox.stub(document, 'createElement', () => ({...styleElement, style: {animationName: ''}}));
-
-    sandbox.stub(document.head, 'appendChild');
-
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-    const name = keyframes({}, 'MyComponent');
-
-    expect(styleElement.sheet.insertRule.lastCall.args[0]).to.equal(
-      '@keyframes ' + name + ' {\n\n}\n'
+    expect(style.innerText).to.equal(
+`@-webkit-keyframes SlideFromLeft--radium-animation-0-1 {
+from{
+  left: -1000px;
+}
+to{
+  left: 0;
+}
+}
+`
     );
   });
 
-  it('serializes keyframes', () => {
-    sandbox.stub(document, 'createElement', () => {
-      return styleElement;
-    });
+  it('renders keyframes from child component', () => {
+    const animation = keyframes({
+      from: {left: '-1000px'},
+      to: {left: 0},
+    }, 'SlideFromLeft');
 
-    sandbox.stub(document.head, 'appendChild');
-
-    const keyframes = require('inject?-./create-markup-for-styles!keyframes.js')({
-      'exenv': exenv,
-      './prefixer': require('__mocks__/prefixer.js')
-    });
-    const name = keyframes({
-      from: {
-        width: 100
-      },
-      to: {
-        width: 200
+    @Radium()
+    class ChildComponent extends Component {
+      render() {
+        return <div style={{animationName: animation}} />;
       }
-    }, 'MyComponent');
+    }
 
-    expect(styleElement.sheet.insertRule.lastCall.args[0]).to.equal(
-      `@-webkit-keyframes ${name} {
-  from {
-    width: 100;
-  }
-  to {
-    width: 200;
-  }
+    @Radium({isRoot: true})
+    class TestComponent extends Component {
+      render() {
+        return (
+          <div>
+            <ChildComponent />
+          </div>
+        );
+      }
+    }
+
+    const output = TestUtils.renderIntoDocument(<TestComponent />);
+
+    const style = getElement(output, 'style');
+
+    expect(style.innerText).to.equal(
+`@-webkit-keyframes SlideFromLeft--radium-animation-0-2 {
+from{
+  left: -1000px;
 }
-`);
+to{
+  left: 0;
+}
+}
+`
+    );
   });
+
 });

--- a/src/__tests__/keyframes-test.js
+++ b/src/__tests__/keyframes-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import Radium, {keyframes} from 'index';
-import {getElement} from 'test-helpers';
+import {expectCSS, getElement} from 'test-helpers';
 import React, {Component} from 'react';
 import TestUtils from 'react-addons-test-utils';
 
@@ -24,17 +24,16 @@ describe('keyframes', () => {
 
     const style = getElement(output, 'style');
 
-    expect(style.innerText).to.equal(
-`@-webkit-keyframes SlideFromLeft-radium-animation-e32ae4d0 {
-from{
-  left: -1000px;
-}
-to{
-  left: 0;
-}
-}
-`
-    );
+    expectCSS(style, `
+      @-webkit-keyframes SlideFromLeft-radium-animation-1b668a10 {
+        from{
+          left: -1000px;
+        }
+        to{
+          left: 0;
+        }
+      }
+    `);
   });
 
   it('renders keyframes from child component', () => {
@@ -65,17 +64,16 @@ to{
 
     const style = getElement(output, 'style');
 
-    expect(style.innerText).to.equal(
-`@-webkit-keyframes SlideFromLeft-radium-animation-e32ae4d0 {
-from{
-  left: -1000px;
-}
-to{
-  left: 0;
-}
-}
-`
-    );
+    expectCSS(style, `
+      @-webkit-keyframes SlideFromLeft-radium-animation-1b668a10 {
+        from{
+          left: -1000px;
+        }
+        to{
+          left: 0;
+        }
+      }
+    `);
   });
 
 });

--- a/src/__tests__/keyframes-test.js
+++ b/src/__tests__/keyframes-test.js
@@ -25,7 +25,7 @@ describe('keyframes', () => {
     const style = getElement(output, 'style');
 
     expect(style.innerText).to.equal(
-`@-webkit-keyframes SlideFromLeft--radium-animation-0-1 {
+`@-webkit-keyframes SlideFromLeft-radium-animation-e32ae4d0 {
 from{
   left: -1000px;
 }
@@ -66,7 +66,7 @@ to{
     const style = getElement(output, 'style');
 
     expect(style.innerText).to.equal(
-`@-webkit-keyframes SlideFromLeft--radium-animation-0-2 {
+`@-webkit-keyframes SlideFromLeft-radium-animation-e32ae4d0 {
 from{
   left: -1000px;
 }

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -5,7 +5,7 @@ import MouseUpListener from 'plugins/mouse-up-listener.js';
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import {getRenderOutput, getElement} from 'test-helpers';
+import {expectCSS, getRenderOutput, getElement} from 'test-helpers';
 
 describe('Radium blackbox tests', () => {
   beforeEach(() => {
@@ -318,19 +318,19 @@ describe('Radium blackbox tests', () => {
 
     const style = getElement(output, 'style');
 
-    expect(style.innerText).to.equal(
-      '@media print{' +
-      '.Radium-TestComponent-foo{\n' +
-      '  color: blue !important;\n' +
-      '}' +
-      '.Radium-TestComponent-bar{\n' +
-      '  background: red !important;\n' +
-      '}' +
-      '.Radium-TestComponent2-main{\n' +
-      '  color: black !important;\n' +
-      '}' +
-      '}'
-    );
+    expectCSS(style, `
+      @media print {
+        .Radium-TestComponent-foo {
+          color: blue !important;
+        }
+        .Radium-TestComponent-bar {
+          background: red !important;
+        }
+        .Radium-TestComponent2-main {
+          color: black !important;
+        }
+      }
+    `);
   });
 
   it('resolves styles if an element has element children and spreads props', () => {

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -336,7 +336,7 @@ describe('Radium blackbox tests', () => {
   it('resolves styles if an element has element children and spreads props', () => {
     @Radium
     class Inner extends Component {
-      propTypes = { children: PropTypes.node }
+      static propTypes = { children: PropTypes.node }
       render() {
         return (
           <div {...this.props} style={[{color: 'blue'}, {background: 'red'}]}>

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -5,18 +5,7 @@ import MouseUpListener from 'plugins/mouse-up-listener.js';
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-
-const getRenderOutput = function(element) {
-  const renderer = TestUtils.createRenderer();
-  renderer.render(element);
-  return renderer.getRenderOutput();
-};
-
-const getElement = function(output, tagName) {
-  return ReactDOM.findDOMNode(
-    TestUtils.findRenderedDOMComponentWithTag(output, tagName)
-  );
-};
+import {getRenderOutput, getElement} from 'test-helpers';
 
 describe('Radium blackbox tests', () => {
   beforeEach(() => {

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -331,9 +331,15 @@ describe('Radium blackbox tests', () => {
 
     expect(style.innerText).to.equal(
       '@media print{' +
-      '.Radium-TestComponent-foo{color: blue !important;}' +
-      '.Radium-TestComponent-bar{background: red !important;}' +
-      '.Radium-TestComponent2-main{color: black !important;}' +
+      '.Radium-TestComponent-foo{\n' +
+      '  color: blue !important;\n' +
+      '}' +
+      '.Radium-TestComponent-bar{\n' +
+      '  background: red !important;\n' +
+      '}' +
+      '.Radium-TestComponent2-main{\n' +
+      '  color: black !important;\n' +
+      '}' +
       '}'
     );
   });

--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+import React from 'react';
+
+import Style from './style.js';
+import StyleKeeper from '../style-keeper';
+
+const StyleSheet = React.createClass({
+  _subscription: ((null: any): {remove: () => void}),
+
+  contextTypes: {
+    _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
+  },
+
+  getInitialState() {
+    return this._getCSSState();
+  },
+
+  componentDidMount() {
+    this._subscription = this.context._radiumStyleKeeper.subscribe(
+      this._onChange
+    );
+    this._onChange();
+  },
+
+  componentWillUnmount() {
+    this._subscription.remove();
+  },
+
+  _getCSSState(): {css: string} {
+    return {css: this.context._radiumStyleKeeper.getCSS()};
+  },
+
+  _onChange() {
+    this.setState(this._getCSSState());
+  },
+
+  render(): ReactElement {
+    return (
+      <style dangerouslySetInnerHTML={{__html: this.state.css}} />
+    );
+  }
+});
+
+export default StyleSheet;

--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -2,12 +2,9 @@
 
 import React, {Component} from 'react';
 
-import Style from './style.js';
 import StyleKeeper from '../style-keeper';
 
 export default class StyleSheet extends Component {
-  _subscription: {remove: () => void};
-
   // $FlowStaticPropertyWarning
   static contextTypes = {
     _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)

--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -11,7 +11,7 @@ export default class StyleSheet extends Component {
   };
 
   constructor() {
-    super();
+    super(...arguments);
 
     this.state = this._getCSSState();
   }

--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -1,45 +1,48 @@
 /* @flow */
 
-import React from 'react';
+import React, {Component} from 'react';
 
 import Style from './style.js';
 import StyleKeeper from '../style-keeper';
 
-const StyleSheet = React.createClass({
-  _subscription: ((null: any): {remove: () => void}),
+export default class StyleSheet extends Component {
+  _subscription: {remove: () => void};
 
-  contextTypes: {
+  // $FlowStaticPropertyWarning
+  static contextTypes = {
     _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
-  },
+  };
 
-  getInitialState() {
-    return this._getCSSState();
-  },
+  constructor() {
+    super();
+
+    this.state = this._getCSSState();
+  }
 
   componentDidMount() {
     this._subscription = this.context._radiumStyleKeeper.subscribe(
       this._onChange
     );
     this._onChange();
-  },
+  }
 
   componentWillUnmount() {
-    this._subscription.remove();
-  },
+    if (this._subscription) {
+      this._subscription.remove();
+    }
+  }
 
   _getCSSState(): {css: string} {
     return {css: this.context._radiumStyleKeeper.getCSS()};
-  },
+  }
 
   _onChange() {
     this.setState(this._getCSSState());
-  },
+  }
 
   render(): ReactElement {
     return (
       <style dangerouslySetInnerHTML={{__html: this.state.css}} />
     );
   }
-});
-
-export default StyleSheet;
+}

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -29,7 +29,7 @@ const Style = React.createClass({
   },
 
   contextTypes: {
-    radiumConfig: React.PropTypes.object
+    _radiumConfig: React.PropTypes.object
   },
 
   getDefaultProps(): {scopeSelector: string} {
@@ -53,8 +53,8 @@ const Style = React.createClass({
         accumulator += buildCssString(
           completeSelector,
           rules,
-          this.context && this.context.radiumConfig &&
-            this.context.radiumConfig.userAgent
+          this.context && this.context._radiumConfig &&
+            this.context._radiumConfig.userAgent
         );
       }
 

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -1,26 +1,8 @@
 /* @flow */
 
-import camelCasePropsToDashCase from '../camel-case-props-to-dash-case';
-import createMarkupForStyles from '../create-markup-for-styles';
-import {getPrefixedStyle} from '../prefixer';
+import cssRuleSetToString from '../css-rule-set-to-string';
 
 import React from 'react';
-
-const buildCssString = function(
-  selector: string,
-  rules: Object,
-  userAgent: ?string,
-): string {
-  if (!selector || !rules) {
-    return '';
-  }
-
-  const prefixedRules = getPrefixedStyle(rules, userAgent);
-  const cssPrefixedRules = camelCasePropsToDashCase(prefixedRules);
-  const serializedRules = createMarkupForStyles(cssPrefixedRules);
-
-  return selector + '{' + serializedRules + '}';
-};
 
 const Style = React.createClass({
   propTypes: {
@@ -50,7 +32,7 @@ const Style = React.createClass({
             this.props.scopeSelector + ' ' :
             ''
           ) + selector;
-        accumulator += buildCssString(
+        accumulator += cssRuleSetToString(
           completeSelector,
           rules,
           this.context && this.context._radiumConfig &&

--- a/src/create-markup-for-styles.js
+++ b/src/create-markup-for-styles.js
@@ -1,9 +1,0 @@
-/* @flow */
-
-const createMarkupForStyles = function(style: Object, spaces: string = ''): string {
-  return Object.keys(style).map(property => {
-    return spaces + property + ': ' + style[property] + ';';
-  }).join('\n');
-};
-
-export default createMarkupForStyles;

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -1,0 +1,21 @@
+/* @flow */
+
+import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
+import createMarkupForStyles from './create-markup-for-styles';
+import {getPrefixedStyle} from './prefixer';
+
+export default function cssRuleSetToString(
+  selector: string,
+  rules: Object,
+  userAgent: ?string,
+): string {
+  if (!selector || !rules) {
+    return '';
+  }
+
+  const prefixedRules = getPrefixedStyle(rules, userAgent);
+  const cssPrefixedRules = camelCasePropsToDashCase(prefixedRules);
+  const serializedRules = createMarkupForStyles(cssPrefixedRules, '  ');
+
+  return selector + '{\n' + serializedRules + '\n}';
+};

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -18,4 +18,4 @@ export default function cssRuleSetToString(
   const serializedRules = createMarkupForStyles(cssPrefixedRules, '  ');
 
   return selector + '{\n' + serializedRules + '\n}';
-};
+}

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -1,8 +1,13 @@
 /* @flow */
 
 import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
-import createMarkupForStyles from './create-markup-for-styles';
 import {getPrefixedStyle} from './prefixer';
+
+function createMarkupForStyles(style: Object): string {
+  return Object.keys(style).map(property => {
+    return property + ': ' + style[property] + ';';
+  }).join('\n');
+}
 
 export default function cssRuleSetToString(
   selector: string,
@@ -15,7 +20,7 @@ export default function cssRuleSetToString(
 
   const prefixedRules = getPrefixedStyle(rules, userAgent);
   const cssPrefixedRules = camelCasePropsToDashCase(prefixedRules);
-  const serializedRules = createMarkupForStyles(cssPrefixedRules, '  ');
+  const serializedRules = createMarkupForStyles(cssPrefixedRules);
 
-  return selector + '{\n' + serializedRules + '\n}';
+  return selector + '{' + serializedRules + '}';
 }

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -4,6 +4,8 @@ import React, {Component, PropTypes} from 'react';
 
 import resolveStyles from './resolve-styles.js';
 import printStyles from './print-styles.js';
+import StyleKeeper from './style-keeper.js';
+import StyleSheet from './components/style-sheet.js';
 
 const KEYS_TO_IGNORE_WHEN_COPYING_PROPERTIES = [
   'arguments',
@@ -15,7 +17,7 @@ const KEYS_TO_IGNORE_WHEN_COPYING_PROPERTIES = [
   'type'
 ];
 
-const copyProperties = function(source, target) {
+function copyProperties(source, target) {
   Object.getOwnPropertyNames(source).forEach(key => {
     if (
       KEYS_TO_IGNORE_WHEN_COPYING_PROPERTIES.indexOf(key) < 0 &&
@@ -25,7 +27,20 @@ const copyProperties = function(source, target) {
       Object.defineProperty(target, key, descriptor);
     }
   });
-};
+}
+
+function _getStyleKeeper(instance): StyleKeeper {
+  if (!instance._radiumStyleKeeper) {
+    const userAgent = (
+      instance.props.radiumConfig && instance.props.radiumConfig.userAgent
+    ) || (
+      instance.context._radiumConfig && instance.context._radiumConfig.userAgent
+    );
+    instance._radiumStyleKeeper = new StyleKeeper(userAgent);
+  }
+
+  return instance._radiumStyleKeeper;
+}
 
 export default function enhanceWithRadium(
   configOrComposedComponent: constructor | Function | Object,
@@ -94,14 +109,21 @@ export default function enhanceWithRadium(
         super.getChildContext() :
         {};
 
-      if (!this.props.radiumConfig) {
+      if (!this.props.radiumConfig && !config.isRoot) {
         return superChildContext;
       }
 
-      return {
-        ...superChildContext,
-        _radiumConfig: this.props._radiumConfig
-      };
+      const newContext = {...superChildContext};
+
+      if (this.props.radiumConfig) {
+        newContext._radiumConfig = this.props.radiumConfig;
+      }
+
+      if (config.isRoot) {
+        newContext._radiumStyleKeeper = _getStyleKeeper(this);
+      }
+
+      return newContext;
     }
 
     render() {
@@ -116,7 +138,18 @@ export default function enhanceWithRadium(
         };
       }
 
-      return resolveStyles(this, renderedElement, currentConfig);
+      const element = resolveStyles(this, renderedElement, currentConfig);
+
+      if (config.isRoot) {
+        return (
+          <div>
+            {element}
+            <StyleSheet />
+          </div>
+        );
+      }
+
+      return element;
     }
   }
 
@@ -152,12 +185,14 @@ export default function enhanceWithRadium(
 
   RadiumEnhancer.contextTypes = {
     ...RadiumEnhancer.contextTypes,
-    _radiumConfig: React.PropTypes.object
+    _radiumConfig: React.PropTypes.object,
+    _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
   };
 
   RadiumEnhancer.childContextTypes = {
     ...RadiumEnhancer.childContextTypes,
-    _radiumConfig: React.PropTypes.object
+    _radiumConfig: React.PropTypes.object,
+    _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
   };
 
   return RadiumEnhancer;

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -100,14 +100,14 @@ export default function enhanceWithRadium(
 
       return {
         ...superChildContext,
-        radiumConfig: this.props.radiumConfig
+        _radiumConfig: this.props._radiumConfig
       };
     }
 
     render() {
       const renderedElement = super.render();
       let currentConfig = this.props.radiumConfig ||
-        this.context.radiumConfig || config;
+        this.context._radiumConfig || config;
 
       if (config && currentConfig !== config) {
         currentConfig = {
@@ -152,12 +152,12 @@ export default function enhanceWithRadium(
 
   RadiumEnhancer.contextTypes = {
     ...RadiumEnhancer.contextTypes,
-    radiumConfig: React.PropTypes.object
+    _radiumConfig: React.PropTypes.object
   };
 
   RadiumEnhancer.childContextTypes = {
     ...RadiumEnhancer.childContextTypes,
-    radiumConfig: React.PropTypes.object
+    _radiumConfig: React.PropTypes.object
   };
 
   return RadiumEnhancer;

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -81,6 +81,10 @@ export default function enhanceWithRadium(
       if (RadiumEnhancer.printStyleClass) {
         this.printStyleClass = RadiumEnhancer.printStyleClass;
       }
+
+      if (config.isRoot) {
+        _getStyleKeeper(this);
+      }
     }
 
     componentWillUnmount() {

--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -1,8 +1,6 @@
 /* @flow */
 
-import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
-import createMarkupForStyles from './create-markup-for-styles';
-import {getPrefixedStyle} from './prefixer';
+import cssRuleSetToString from './css-rule-set-to-string';
 
 import ExecutionEnvironment from 'exenv';
 
@@ -32,47 +30,34 @@ if (ExecutionEnvironment.canUseDOM) {
 const animationNameSeed = ExecutionEnvironment.canUseDOM
   ? document.head.querySelectorAll('style').length
   : 0;
+
 let animationIndex = 1;
-let animationStyleSheet = null;
 
-if (isAnimationSupported) {
-  animationStyleSheet = (document.createElement('style'): any);
-  document.head.appendChild(animationStyleSheet);
-}
-
-// Simple animation helper that injects CSS into a style object containing the
-// keyframes, and returns a string with the generated animation name.
 export default function keyframes(
   keyframeRules: {[percentage: string]: {[key: string]: string|number}},
-  componentName?: string,
-  prefix: (style: Object) => Object = getPrefixedStyle
-): string {
-  const name = `-radium-animation-${animationNameSeed}-${animationIndex}`;
+  name?: string,
+): {
+  __radiumKeyframes: bool,
+  name: string,
+  getCSS(userAgent: string): string
+} {
+  const animationName = (name ? name + '-' : '') + '-radium-animation-' + animationNameSeed + '-' + animationIndex;
   animationIndex += 1;
 
-  if (!isAnimationSupported) {
-    return name;
-  }
-
-  const rule = '@' + keyframesPrefixed + ' ' + name + ' {\n' +
-    Object.keys(keyframeRules).map(percentage => {
-      const props = keyframeRules[percentage];
-      const prefixedProps = prefix(props);
-      const cssPrefixedProps = camelCasePropsToDashCase(prefixedProps);
-      const serializedProps = createMarkupForStyles(cssPrefixedProps, '  ');
-      return '  ' + percentage + ' {\n  ' + serializedProps + '\n  }';
-    }).join('\n') +
-    '\n}\n';
-
-  // for flow
-  /* istanbul ignore next */
-  if (!animationStyleSheet) {
-    throw new Error('keyframes not initialized properly');
-  }
-
-  animationStyleSheet.sheet.insertRule(
-    rule,
-    animationStyleSheet.sheet.cssRules.length
-  );
-  return name;
+  return {
+    __radiumKeyframes: true,
+    name: animationName,
+    getCSS(userAgent: string) {
+      const keyframesPrefixed = '-webkit-keyframes';
+      return '@' + keyframesPrefixed + ' ' + animationName + ' {\n' +
+        Object.keys(keyframeRules).map(percentage =>
+          cssRuleSetToString(
+            percentage,
+            keyframeRules[percentage],
+            userAgent
+          )
+        ).join('\n') +
+        '\n}\n';
+    }
+  };
 }

--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -20,7 +20,8 @@ export default function keyframes(
   keyframeRules: {[percentage: string]: {[key: string]: string|number}},
   name?: string,
 ): Keyframes {
-  const animationName = (name ? name + '-' : '') + '-radium-animation-' + animationNameSeed + '-' + animationIndex;
+  const animationName = (name ? name + '-' : '') +
+    '-radium-animation-' + animationNameSeed + '-' + animationIndex;
   animationIndex += 1;
 
   return {

--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -4,28 +4,11 @@ import cssRuleSetToString from './css-rule-set-to-string';
 
 import ExecutionEnvironment from 'exenv';
 
-let isAnimationSupported = false;
-let keyframesPrefixed = 'keyframes';
-
-if (ExecutionEnvironment.canUseDOM) {
-  // Animation feature detection and keyframes prefixing from MDN:
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Detecting_CSS_animation_support
-  const domPrefixes = ['Webkit', 'Moz', 'O', 'ms'];
-  const element = (document.createElement('div'): any);
-
-  if (element.style.animationName !== undefined) {
-    isAnimationSupported = true;
-  } else {
-    domPrefixes.some(prefix => {
-      if (element.style[prefix + 'AnimationName'] !== undefined) {
-        keyframesPrefixed = '-' + prefix.toLowerCase() + '-keyframes';
-        isAnimationSupported = true;
-        return true;
-      }
-      return false;
-    });
-  }
-}
+export type Keyframes = {
+  __radiumKeyframes: bool,
+  __name: string,
+  __getCSS(userAgent?: string): string
+};
 
 const animationNameSeed = ExecutionEnvironment.canUseDOM
   ? document.head.querySelectorAll('style').length
@@ -36,18 +19,14 @@ let animationIndex = 1;
 export default function keyframes(
   keyframeRules: {[percentage: string]: {[key: string]: string|number}},
   name?: string,
-): {
-  __radiumKeyframes: bool,
-  name: string,
-  getCSS(userAgent: string): string
-} {
+): Keyframes {
   const animationName = (name ? name + '-' : '') + '-radium-animation-' + animationNameSeed + '-' + animationIndex;
   animationIndex += 1;
 
   return {
     __radiumKeyframes: true,
-    name: animationName,
-    getCSS(userAgent: string) {
+    __name: animationName,
+    __getCSS(userAgent?: string) {
       const keyframesPrefixed = '-webkit-keyframes';
       return '@' + keyframesPrefixed + ' ' + animationName + ' {\n' +
         Object.keys(keyframeRules).map(percentage =>

--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -2,42 +2,45 @@
 
 import cssRuleSetToString from './css-rule-set-to-string';
 
-import ExecutionEnvironment from 'exenv';
-
 export type Keyframes = {
   __radiumKeyframes: bool,
-  __name: string,
-  __getCSS(userAgent?: string): string
+  __process(userAgent?: string): {animationName: string, css: string},
 };
 
-const animationNameSeed = ExecutionEnvironment.canUseDOM
-  ? document.head.querySelectorAll('style').length
-  : 0;
+// a simple djb2 hash based on hash-string:
+// https://github.com/MatthewBarker/hash-string/blob/master/source/hash-string.js
+function hash(text) {
+  let hash = 5381;
+  let index = text.length - 1;
 
-let animationIndex = 1;
+  while (index) {
+    hash = (hash * 33) ^ text.charCodeAt(index);
+    index -= 1;
+  }
+
+  return (hash >>> 0).toString(16);
+}
 
 export default function keyframes(
   keyframeRules: {[percentage: string]: {[key: string]: string|number}},
   name?: string,
 ): Keyframes {
-  const animationName = (name ? name + '-' : '') +
-    '-radium-animation-' + animationNameSeed + '-' + animationIndex;
-  animationIndex += 1;
-
   return {
     __radiumKeyframes: true,
-    __name: animationName,
-    __getCSS(userAgent?: string) {
+    __process(userAgent) {
       const keyframesPrefixed = '-webkit-keyframes';
-      return '@' + keyframesPrefixed + ' ' + animationName + ' {\n' +
-        Object.keys(keyframeRules).map(percentage =>
-          cssRuleSetToString(
-            percentage,
-            keyframeRules[percentage],
-            userAgent
-          )
-        ).join('\n') +
+      const rules = Object.keys(keyframeRules).map(percentage =>
+        cssRuleSetToString(
+          percentage,
+          keyframeRules[percentage],
+          userAgent
+        )
+      ).join('\n');
+      const animationName = (name ? name + '-' : '') + 'radium-animation-' + hash(rules);
+      const css = '@' + keyframesPrefixed + ' ' + animationName + ' {\n' +
+        rules +
         '\n}\n';
+      return {css, animationName};
     }
   };
 }

--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -10,15 +10,15 @@ export type Keyframes = {
 // a simple djb2 hash based on hash-string:
 // https://github.com/MatthewBarker/hash-string/blob/master/source/hash-string.js
 function hash(text) {
-  let hash = 5381;
+  let hashValue = 5381;
   let index = text.length - 1;
 
   while (index) {
-    hash = (hash * 33) ^ text.charCodeAt(index);
+    hashValue = (hashValue * 33) ^ text.charCodeAt(index);
     index -= 1;
   }
 
-  return (hash >>> 0).toString(16);
+  return (hashValue >>> 0).toString(16);
 }
 
 export default function keyframes(

--- a/src/plugins/check-props-plugin.js
+++ b/src/plugins/check-props-plugin.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {PluginConfig, PluginResult} from '.';
+import type {PluginConfig, PluginResult} from './index';
 
 let checkProps = (() => {}: any);
 

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -10,6 +10,9 @@ import resolveInteractionStylesPlugin from './resolve-interaction-styles-plugin'
 import resolveMediaQueriesPlugin from './resolve-media-queries-plugin';
 
 export type PluginConfig = {
+  // Adds a chunk of css to the root style sheet
+  addCSS: (css: string) => {remove: () => void},
+
   // May not be readable if code has been minified
   componentName: string,
 

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -4,6 +4,7 @@
 import type {Config} from '../config';
 
 import checkPropsPlugin from './check-props-plugin';
+import keyframesPlugin from './keyframes-plugin';
 import mergeStyleArrayPlugin from './merge-style-array-plugin';
 import prefixPlugin from './prefix-plugin';
 import resolveInteractionStylesPlugin from './resolve-interaction-styles-plugin';
@@ -73,6 +74,7 @@ export type PluginResult = ?{
 
 export default {
   checkProps: checkPropsPlugin,
+  keyframes: keyframesPlugin,
   mergeStyleArray: mergeStyleArrayPlugin,
   prefix: prefixPlugin,
   resolveInteractionStyles: resolveInteractionStylesPlugin,

--- a/src/plugins/keyframes-plugin.js
+++ b/src/plugins/keyframes-plugin.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import type {PluginConfig, PluginResult} from '.';
+
+export default function keyframesPlugin(
+  {addCSS, config, getComponentField, style}: PluginConfig
+): PluginResult {
+  const newStyle = Object.keys(style).reduce((newStyle, key) => {
+    let value = style[key];
+    if (key === 'animationName' && value && value.__radiumKeyframes) {
+      const css = value.getCSS(config.userAgent);
+      addCSS(css);
+      value = value.name;
+    }
+
+    newStyle[key] = value;
+    return newStyle;
+  }, {});
+  return {style: newStyle};
+}

--- a/src/plugins/keyframes-plugin.js
+++ b/src/plugins/keyframes-plugin.js
@@ -10,9 +10,9 @@ export default function keyframesPlugin(
     let value = style[key];
     if (key === 'animationName' && value && value.__radiumKeyframes) {
       const keyframesValue = (value: Keyframes);
-      const css = keyframesValue.__getCSS(config.userAgent);
+      const {animationName, css} = keyframesValue.__process(config.userAgent);
       addCSS(css);
-      value = keyframesValue.__name;
+      value = animationName;
     }
 
     newStyle[key] = value;

--- a/src/plugins/keyframes-plugin.js
+++ b/src/plugins/keyframes-plugin.js
@@ -4,9 +4,9 @@ import type {PluginConfig, PluginResult} from './index';
 import type {Keyframes} from '../keyframes';
 
 export default function keyframesPlugin(
-  {addCSS, config, getComponentField, style}: PluginConfig
+  {addCSS, config, style}: PluginConfig // eslint-disable-line no-shadow
 ): PluginResult {
-  const newStyle = Object.keys(style).reduce((newStyle, key) => {
+  const newStyle = Object.keys(style).reduce((newStyleInProgress, key) => {
     let value = style[key];
     if (key === 'animationName' && value && value.__radiumKeyframes) {
       const keyframesValue = (value: Keyframes);
@@ -15,8 +15,8 @@ export default function keyframesPlugin(
       value = animationName;
     }
 
-    newStyle[key] = value;
-    return newStyle;
+    newStyleInProgress[key] = value;
+    return newStyleInProgress;
   }, {});
   return {style: newStyle};
 }

--- a/src/plugins/keyframes-plugin.js
+++ b/src/plugins/keyframes-plugin.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type {PluginConfig, PluginResult} from '.';
+import type {Keyframes} from '../keyframes';
 
 export default function keyframesPlugin(
   {addCSS, config, getComponentField, style}: PluginConfig
@@ -8,9 +9,10 @@ export default function keyframesPlugin(
   const newStyle = Object.keys(style).reduce((newStyle, key) => {
     let value = style[key];
     if (key === 'animationName' && value && value.__radiumKeyframes) {
-      const css = value.getCSS(config.userAgent);
+      const keyframesValue = (value: Keyframes);
+      const css = keyframesValue.__getCSS(config.userAgent);
       addCSS(css);
-      value = value.name;
+      value = keyframesValue.__name;
     }
 
     newStyle[key] = value;

--- a/src/plugins/keyframes-plugin.js
+++ b/src/plugins/keyframes-plugin.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {PluginConfig, PluginResult} from '.';
+import type {PluginConfig, PluginResult} from './index';
 import type {Keyframes} from '../keyframes';
 
 export default function keyframesPlugin(

--- a/src/plugins/merge-style-array-plugin.js
+++ b/src/plugins/merge-style-array-plugin.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {PluginConfig, PluginResult} from '.';
+import type {PluginConfig, PluginResult} from './index';
 
 // Convenient syntax for multiple styles: `style={[style1, style2, etc]}`
 // Ignores non-objects, so you can do `this.state.isCool && styles.cool`.

--- a/src/plugins/prefix-plugin.js
+++ b/src/plugins/prefix-plugin.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {PluginConfig, PluginResult} from '.';
+import type {PluginConfig, PluginResult} from './index';
 
 import {getPrefixedStyle} from '../prefixer';
 

--- a/src/plugins/resolve-interaction-styles-plugin.js
+++ b/src/plugins/resolve-interaction-styles-plugin.js
@@ -1,6 +1,6 @@
 /** @flow */
 
-import type {PluginConfig, PluginResult} from '.';
+import type {PluginConfig, PluginResult} from './index';
 
 import MouseUpListener from './mouse-up-listener';
 

--- a/src/plugins/resolve-media-queries-plugin.js
+++ b/src/plugins/resolve-media-queries-plugin.js
@@ -1,7 +1,7 @@
 /** @flow */
 
 import type {MatchMediaType} from '../config';
-import type {PluginConfig, PluginResult} from '.';
+import type {PluginConfig, PluginResult} from './index';
 
 let _windowMatchMedia;
 const _getWindowMatchMedia = function(ExecutionEnvironment) {

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -16,6 +16,7 @@ const DEFAULT_CONFIG = {
     Plugins.checkProps,
     Plugins.resolveMediaQueries,
     Plugins.resolveInteractionStyles,
+    Plugins.keyframes,
     Plugins.prefix,
     Plugins.checkProps
   ]

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -207,14 +207,17 @@ const _runPlugins = function({
     _setStyleState(component, elementKey || getKey(), stateKey, value);
 
   const addCSS = css => {
-    if (!component.context._radiumStyleKeeper) {
+    const styleKeeper = component._radiumStyleKeeper ||
+      component.context._radiumStyleKeeper;
+    if (!styleKeeper) {
+      console.log(Object.keys(component));
       throw new Error(
         'To use plugins requiring `addCSS` (e.g. keyframes), please add ' +
           '`isRoot: true` to your root component\'s Radium config.',
       );
     }
 
-    return component.context._radiumStyleKeeper.addCSS(css);
+    return styleKeeper.addCSS(css);
   };
 
   let newStyle = props.style;

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -205,10 +205,23 @@ const _runPlugins = function({
   const setState = (stateKey, value, elementKey) =>
     _setStyleState(component, elementKey || getKey(), stateKey, value);
 
+  const addCSS = css => {
+    if (!component.context._radiumStyleKeeper) {
+      throw new Error(
+        'To use keyframes, please add `isRoot: true` to your root ' +
+          'component\'s Radium config.',
+      );
+    }
+
+    return component.context._radiumStyleKeeper.addCSS(css);
+  };
+
   let newStyle = props.style;
+
   plugins.forEach(plugin => {
     const result = plugin({
       ExecutionEnvironment,
+      addCSS,
       componentName,
       config,
       getComponentField,

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -209,8 +209,8 @@ const _runPlugins = function({
   const addCSS = css => {
     if (!component.context._radiumStyleKeeper) {
       throw new Error(
-        'To use keyframes, please add `isRoot: true` to your root ' +
-          'component\'s Radium config.',
+        'To use plugins requiring `addCSS` (e.g. keyframes), please add ' +
+          '`isRoot: true` to your root component\'s Radium config.',
       );
     }
 

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -210,7 +210,6 @@ const _runPlugins = function({
     const styleKeeper = component._radiumStyleKeeper ||
       component.context._radiumStyleKeeper;
     if (!styleKeeper) {
-      console.log(Object.keys(component));
       throw new Error(
         'To use plugins requiring `addCSS` (e.g. keyframes), please add ' +
           '`isRoot: true` to your root component\'s Radium config.',

--- a/src/style-keeper.js
+++ b/src/style-keeper.js
@@ -1,0 +1,52 @@
+/* @flow */
+
+import cssRuleSetToString from './css-rule-set-to-string';
+
+export default class StyleKeeper {
+  _userAgent: string;
+  _listeners: Array<() => void>;
+  _cssSet: {[id: string]: bool};
+
+  constructor(userAgent: string) {
+    this._userAgent = userAgent;
+    this._listeners = [];
+    this._cssSet = {};
+  }
+
+  subscribe(listener: () => void): {remove: () => void} {
+    if (this._listeners.indexOf(listener) === -1) {
+      this._listeners.push(listener);
+    }
+
+    return {
+      remove() {
+        const listenerIndex = this._listeners.indexOf(listener);
+        if (listenerIndex > -1) {
+          this._listeners.splice(listenerIndex, 1);
+        }
+      }
+    };
+  }
+
+  addCSS(css: string): {remove: () => void} {
+    if (!this._cssSet[css]) {
+      this._cssSet[css] = true;
+      this._emitChange();
+    }
+
+    return {
+      remove() {
+        delete this._cssSet[css];
+        this._emitChange();
+      }
+    };
+  }
+
+  getCSS(): string {
+    return Object.keys(this._cssSet).join('\n');
+  }
+
+  _emitChange() {
+    this._listeners.forEach(listener => listener());
+  }
+}

--- a/src/style-keeper.js
+++ b/src/style-keeper.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import cssRuleSetToString from './css-rule-set-to-string';
-
 export default class StyleKeeper {
   _userAgent: string;
   _listeners: Array<() => void>;

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -12,3 +12,15 @@ export function getElement(output, tagName) {
     TestUtils.findRenderedDOMComponentWithTag(output, tagName)
   );
 }
+
+function cleanCSS(css) {
+  return css.replace(/\s*\n\s*/g, '').replace(/\s*([{};:])\s*/g, '$1');
+}
+
+export function expectCSS(styleElement, css) {
+  // strip newlines and excess whitespace from both to normalize browsers.
+  // IE9, for instance, does not include new lines in innerText.
+  // Also allows us to write our expected CSS cleanly, without worring about the
+  // format of the actual output.
+  expect(cleanCSS(styleElement.innerText)).to.equal(cleanCSS(css));
+}

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -1,0 +1,14 @@
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+export function getRenderOutput(element) {
+  const renderer = TestUtils.createRenderer();
+  renderer.render(element);
+  return renderer.getRenderOutput();
+}
+
+export function getElement(output, tagName) {
+  return ReactDOM.findDOMNode(
+    TestUtils.findRenderedDOMComponentWithTag(output, tagName)
+  );
+}


### PR DESCRIPTION
Allow keyframes to be rendered correctly on the server. Uses React to render a style sheet with the keyframes.

Requires you to mark your App component with `isRoot`, and causes the rendered element from your root App component to be wrapped in a div, so a style element after.

Exposes a new method to plugins, `addCSS` which causes a chunk of CSS to be added to the aforementioned style shset.

Because the style sheet component appears after the user’s rendered elements, the chunks are added correctly during a server-side render.

A StyleKeeper is created in the root component and passed down via context to the children, who can add CSS as they want.

Keyframes is now a combination of the `Radium.keyframes` helper, which creates an opaque object that must be assigned to the `animationName` property. The plugin, `Radium.Plugins.keyframes`, detects this special object, calls `addCSS`, and transforms the value into the actual animation name.

This same mechanism will also be used to add media query styles.