### PR TITLE
Correct and clarify media query syntax

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -42,11 +42,11 @@ var styles = {
     },
 
     // Media queries must start with @media, and follow the same syntax as CSS
-    '@media (min-width: 992px)': {
+    '@media (minWidth: 992px)': {
       padding: '0.6em 1.2em'
     },
 
-    '@media (min-width: 1200px)': {
+    '@media (minWidth: 1200px)': {
       padding: '0.8em 1.5em',
 
       // Media queries can also have nested :hover, :focus, or :active states
@@ -433,7 +433,20 @@ import Radium, { Style } from 'radium'
     fontFamily: 'Helvetica Neue, Helvetica, Arial, sans-serif'
   },
   html: {
-    background: '#ccc'
+    background: '#ccc',
+    fontSize: '100%'
+  },
+  mediaQueries: {
+    '(min-width: 550px)': {
+      html:  {
+        fontSize: '120%'
+      }
+    },
+    '(min-width: 1200px)': {
+      html:  {
+        fontSize: '140%'
+      }
+    }
   },
   'h1, h2, h3': {
     fontWeight: 'bold'


### PR DESCRIPTION
Based on real-world usage of version 0.15.3, including server-side rendering.

* style objects need camel-cased selectors, prefixed with `@media`
* `<Style/>` components need dasherized selectors, nested in a `mediaQueries` key