### PR TITLE
Make animation name more unique

### DIFF
--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -29,6 +29,7 @@ if (ExecutionEnvironment.canUseDOM) {
   }
 }
 
+const animationNameSeed = document.head.querySelectorAll('style').length;
 let animationIndex = 1;
 let animationStyleSheet = null;
 
@@ -44,7 +45,7 @@ export default function keyframes(
   componentName?: string,
   prefix: (style: Object) => Object = getPrefixedStyle
 ): string {
-  const name = 'Animation' + animationIndex;
+  const name = `-radium-animation-${animationNameSeed}-${animationIndex}`;
   animationIndex += 1;
 
   if (!isAnimationSupported) {


### PR DESCRIPTION
To make the animation name more environmentally friendly (so that it doesn't clash with external css) use a radium specific name "-radium-animation-x-y"
To stop animation names clashing between radium versions (a dependency which depends on a different radium package and therefore has it's own radium) seed the name with the number of style sheets already appended to head "x" with the number of current animations as before "y"

The name could actually be anything including a hash of the rule or "document.head.childElementCount" for example, but this seemed to be the most elegant way with little overhead.

Had to change the tests because the sinon stubs were misbehaving and interfering with the original methods even after restoration. Less DRY but makes test much more isolated.