### PR TITLE
Add StyleRoot component to replace isRoot config

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,7 +4,6 @@
 
 - [Sample Style Object](#sample-style-object)
 - [Radium](#radium)
-  - [config.isRoot](#configisroot)
   - [config.matchMedia](#configmatchmedia)
   - [config.plugins](#configplugins)
   - [config.userAgent](#configuseragent)
@@ -12,6 +11,7 @@
 - [keyframes](#keyframes)
 - [Plugins](#plugins)
 - [Style Component](#style-component)
+- [StyleRoot Component](#styleroot-component)
 - [PrintStyleSheet Component](#printstylesheet-component)
 
 
@@ -143,15 +143,9 @@ Alternatively, if the config value can change every time the component is render
 The config will be passed down via [context](https://facebook.github.io/react/docs/context.html) to all child components. Fields in the `radiumConfig` prop or context will override those passed into the `Radium()` function.
 
 Possible configuration values:
-- [config.isRoot](#configisroot)
 - [`matchMedia`](#configmatchmedia)
 - [`plugins`](#configplugins)
 - [`userAgent`](#configuseragent)
-
-### config.isRoot
-**boolean**
-
-Marks the component as the Radium root. Usually used on your top-level App component. `isRoot` will wrap the element returned in your root component's render function in a plain `div` in order to render a second element, the root style sheet. Radium plugins, like keyframes, use this style sheet to inject CSS at runtime. Because the style sheet appears after your rendered elements, it is populated correctly during a server render.
 
 ### config.matchMedia
 
@@ -282,7 +276,7 @@ Radium.getState(this.state, 'button', ':hover')
 
 **Radium.keyframes(keyframes, [name])**
 
-Create a keyframes animation for use in an inline style. `keyframes` returns an opaque object you must assign to the `animationName` property. `Plugins.keyframes` detects the object and adds CSS to the Radium root's style sheet. Radium will automatically apply vendor prefixing to keyframe styles. In order to use `keyframes`, you must wrap your top level element in Radium and provide the `isRoot: true` config value.
+Create a keyframes animation for use in an inline style. `keyframes` returns an opaque object you must assign to the `animationName` property. `Plugins.keyframes` detects the object and adds CSS to the Radium root's style sheet. Radium will automatically apply vendor prefixing to keyframe styles. In order to use `keyframes`, you must wrap your application in the [`StyleRoot component`](#styleroot-component).
 
 `keyframes` takes an optional second parameter, a `name` to prepend to the animation's name to aid in debugging.
 
@@ -484,6 +478,27 @@ A string that any included selectors in `rules` will be appended to. Use to scop
   />
 </div>
 ```
+
+## StyleRoot Component
+
+Usually wrapped around your top-level App component. StyleRoot wraps its children in a plain div followed by the root style sheet. Radium plugins, like keyframes, use this style sheet to inject CSS at runtime. Because the style sheet appears after your rendered elements, it is populated correctly during a server render.
+
+StyleRoot transfers all of its props to the rendered `div`, and is itself wrapped in Radium, so you can pass it inline styles.
+
+```jsx
+import {StyleRoot} from 'radium';
+
+class App extends React.Component {
+  render() {
+    return (
+      <StyleRoot>
+        ... rest of your app ...
+      </StyleRoot>
+    );
+  }
+}  
+```
+
 
 ## PrintStyleSheet component
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -481,7 +481,7 @@ A string that any included selectors in `rules` will be appended to. Use to scop
 
 ## StyleRoot Component
 
-Usually wrapped around your top-level App component. StyleRoot wraps its children in a plain div followed by the root style sheet. Radium plugins, like keyframes, use this style sheet to inject CSS at runtime. Because the style sheet appears after your rendered elements, it is populated correctly during a server render.
+Usually wrapped around your top-level App component. StyleRoot wraps its children in a plain div followed by the root style sheet. Radium plugins, like keyframes and media queries, use this style sheet to inject CSS at runtime. Because the style sheet appears after your rendered elements, it is populated correctly during a server render.
 
 StyleRoot transfers all of its props to the rendered `div`, and is itself wrapped in Radium, so you can pass it inline styles.
 
@@ -491,8 +491,37 @@ import {StyleRoot} from 'radium';
 class App extends React.Component {
   render() {
     return (
-      <StyleRoot>
+      <StyleRoot style={{...}}>
         ... rest of your app ...
+      </StyleRoot>
+    );
+  }
+}  
+```
+
+**Note:** StyleRoot passes the style-keeper (the object where styles are collected) down to other Radium components via context. Because of this, you cannot use keyframes or media queries in *direct children* of the `<StyleRoot>`, e.g.
+
+```jsx
+// COUNTEREXAMPLE, DOES NOT WORK
+<StyleRoot>
+  <div style={{'@media print': {color: black}}} />
+</StyleRoot>
+```
+
+You'll have to break out that piece into a proper component:
+
+```jsx
+class BodyText extends React.Component {
+  render() {
+    return <div style={{'@media print': {color: black}}} />;
+  }
+}
+
+class App extends React.Component {
+  render() {
+    return (
+      <StyleRoot>
+        <BodyText>...</BodyText>
       </StyleRoot>
     );
   }

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -15,9 +15,9 @@ var React = require('react');
 
 var Button = require('./components/button.jsx');
 var ComputedWell = require('./components/computed-well.jsx');
-var Style = require('../src/components/style.js');
-var PrintStyleSheet = require('../src/components/print-style-sheet.js');
 var Radium = require('../src');
+
+var {Style, StyleRoot, PrintStyleSheet} = Radium;
 
 //
 // Radium with ES6 class syntax
@@ -53,7 +53,6 @@ class TwoSquares extends React.Component {
 }
 
 var Spinner = React.createClass({
-
   statics: {
     printStyles: {
       main: {
@@ -78,7 +77,6 @@ Spinner = Radium(Spinner);
 
 
 var App = React.createClass({
-
   _remount: function() {
     this.setState({shouldRenderNull: true});
 
@@ -93,7 +91,7 @@ var App = React.createClass({
     }
 
     return (
-      <div>
+      <StyleRoot>
         <p /><HoverMessage />
 
         <p /><TwoSquares />
@@ -162,11 +160,11 @@ var App = React.createClass({
         </div>
 
         <PrintStyleSheet />
-      </div>
+      </StyleRoot>
     );
   }
 });
-App = Radium({isRoot: true})(App);
+App = Radium(App);
 
 var squareStyles = {
   both: {

--- a/src/__tests__/keyframes-test.js
+++ b/src/__tests__/keyframes-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 
-import Radium, {keyframes} from 'index';
+import Radium, {StyleRoot, keyframes} from 'index';
 import {expectCSS, getElement} from 'test-helpers';
 import React, {Component} from 'react';
 import TestUtils from 'react-addons-test-utils';
@@ -13,10 +13,9 @@ describe('keyframes', () => {
       to: {left: 0}
     }, 'SlideFromLeft');
 
-    @Radium({isRoot: true})
     class TestComponent extends Component {
       render() {
-        return <div style={{animationName: animation}} />;
+        return <StyleRoot style={{animationName: animation}} />;
       }
     }
 
@@ -42,20 +41,20 @@ describe('keyframes', () => {
       to: {left: 0}
     }, 'SlideFromLeft');
 
-    @Radium()
+    @Radium
     class ChildComponent extends Component {
       render() {
         return <div style={{animationName: animation}} />;
       }
     }
 
-    @Radium({isRoot: true})
+    @Radium
     class TestComponent extends Component {
       render() {
         return (
-          <div>
+          <StyleRoot>
             <ChildComponent />
-          </div>
+          </StyleRoot>
         );
       }
     }

--- a/src/__tests__/media-query-test.js
+++ b/src/__tests__/media-query-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 
-import Radium from 'index.js';
+import Radium, {StyleRoot} from 'index';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
@@ -199,8 +199,9 @@ describe('Media query tests', () => {
       matches: true
     }));
 
-    @Radium({isRoot: true, matchMedia})
-    class TestComponent extends Component {
+
+    @Radium
+    class ChildComponent extends Component {
       render() {
         return (
           <span style={{
@@ -210,15 +211,27 @@ describe('Media query tests', () => {
       }
     }
 
+    @Radium({matchMedia})
+    class TestComponent extends Component {
+      render() {
+        return (
+          <StyleRoot>
+            <ChildComponent />
+          </StyleRoot>
+        );
+      }
+    }
+
     const output = TestUtils.renderIntoDocument(<TestComponent />);
 
     const span = getElement(output, 'span');
-    expect(span.className.trim()).to.equal('4e3582ec');
+    const className = span.className.trim();
+    expect(className).to.not.be.empty;
 
     const style = getElement(output, 'style');
     expectCSS(style, `
       @media (min-width:600px){
-        .4e3582ec{
+        .${className}{
           background:red !important;
           color:blue !important;
         }

--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -19,17 +19,7 @@ function _getStyleKeeper(instance): StyleKeeper {
   return instance._radiumStyleKeeper;
 }
 
-@Enhancer
 class StyleRoot extends Component {
-  static contextTypes = {
-    _radiumConfig: PropTypes.object,
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
-  };
-
-  static childContextTypes = {
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
-  };
-
   constructor() {
     super(...arguments);
 
@@ -49,5 +39,16 @@ class StyleRoot extends Component {
     );
   }
 }
+
+StyleRoot.contextTypes = {
+  _radiumConfig: PropTypes.object,
+  _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+};
+
+StyleRoot.childContextTypes = {
+  _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+};
+
+StyleRoot = Enhancer(StyleRoot);
 
 export default StyleRoot;

--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -1,0 +1,53 @@
+/* @flow */
+
+import React, {Component, PropTypes} from 'react';
+
+import Enhancer from '../enhancer';
+import StyleKeeper from '../style-keeper';
+import StyleSheet from './style-sheet';
+
+function _getStyleKeeper(instance): StyleKeeper {
+  if (!instance._radiumStyleKeeper) {
+    const userAgent = (
+      instance.props.radiumConfig && instance.props.radiumConfig.userAgent
+    ) || (
+      instance.context._radiumConfig && instance.context._radiumConfig.userAgent
+    );
+    instance._radiumStyleKeeper = new StyleKeeper(userAgent);
+  }
+
+  return instance._radiumStyleKeeper;
+}
+
+@Enhancer
+class StyleRoot extends Component {
+  static contextTypes = {
+    _radiumConfig: PropTypes.object,
+    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+  };
+
+  static childContextTypes = {
+    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+  };
+
+  constructor() {
+    super(...arguments);
+
+    _getStyleKeeper(this);
+  }
+
+  getChildContext() {
+    return {_radiumStyleKeeper: _getStyleKeeper(this)};
+  }
+
+  render() {
+    return (
+      <div {...this.props}>
+        {this.props.children}
+        <StyleSheet />
+      </div>
+    );
+  }
+}
+
+export default StyleRoot;

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, {Component, PropTypes} from 'react';
+import {Component, PropTypes} from 'react';
 
 import StyleKeeper from './style-keeper';
 import resolveStyles from './resolve-styles.js';
@@ -29,7 +29,7 @@ function copyProperties(source, target) {
 }
 
 export default function enhanceWithRadium(
-  configOrComposedComponent: constructor | Function | Object,
+  configOrComposedComponent: Class<any> | constructor | Function | Object,
   config?: Object = {},
 ): constructor {
   if (typeof configOrComposedComponent !== 'function') {

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -2,10 +2,9 @@
 
 import React, {Component, PropTypes} from 'react';
 
+import StyleKeeper from './style-keeper';
 import resolveStyles from './resolve-styles.js';
 import printStyles from './print-styles.js';
-import StyleKeeper from './style-keeper.js';
-import StyleSheet from './components/style-sheet.js';
 
 const KEYS_TO_IGNORE_WHEN_COPYING_PROPERTIES = [
   'arguments',
@@ -27,19 +26,6 @@ function copyProperties(source, target) {
       Object.defineProperty(target, key, descriptor);
     }
   });
-}
-
-function _getStyleKeeper(instance): StyleKeeper {
-  if (!instance._radiumStyleKeeper) {
-    const userAgent = (
-      instance.props.radiumConfig && instance.props.radiumConfig.userAgent
-    ) || (
-      instance.context._radiumConfig && instance.context._radiumConfig.userAgent
-    );
-    instance._radiumStyleKeeper = new StyleKeeper(userAgent);
-  }
-
-  return instance._radiumStyleKeeper;
 }
 
 export default function enhanceWithRadium(
@@ -81,10 +67,6 @@ export default function enhanceWithRadium(
       if (RadiumEnhancer.printStyleClass) {
         this.printStyleClass = RadiumEnhancer.printStyleClass;
       }
-
-      if (config.isRoot) {
-        _getStyleKeeper(this);
-      }
     }
 
     componentWillUnmount() {
@@ -113,7 +95,7 @@ export default function enhanceWithRadium(
         super.getChildContext() :
         {};
 
-      if (!this.props.radiumConfig && !config.isRoot) {
+      if (!this.props.radiumConfig) {
         return superChildContext;
       }
 
@@ -121,10 +103,6 @@ export default function enhanceWithRadium(
 
       if (this.props.radiumConfig) {
         newContext._radiumConfig = this.props.radiumConfig;
-      }
-
-      if (config.isRoot) {
-        newContext._radiumStyleKeeper = _getStyleKeeper(this);
       }
 
       return newContext;
@@ -142,18 +120,7 @@ export default function enhanceWithRadium(
         };
       }
 
-      const element = resolveStyles(this, renderedElement, currentConfig);
-
-      if (config.isRoot) {
-        return (
-          <div>
-            {element}
-            <StyleSheet />
-          </div>
-        );
-      }
-
-      return element;
+      return resolveStyles(this, renderedElement, currentConfig);
     }
   }
 
@@ -189,14 +156,14 @@ export default function enhanceWithRadium(
 
   RadiumEnhancer.contextTypes = {
     ...RadiumEnhancer.contextTypes,
-    _radiumConfig: React.PropTypes.object,
-    _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
+    _radiumConfig: PropTypes.object,
+    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
   };
 
   RadiumEnhancer.childContextTypes = {
     ...RadiumEnhancer.childContextTypes,
-    _radiumConfig: React.PropTypes.object,
-    _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
+    _radiumConfig: PropTypes.object,
+    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
   };
 
   return RadiumEnhancer;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Enhancer from './enhancer';
 import Plugins from './plugins';
 import PrintStyleSheet from './components/print-style-sheet';
 import Style from './components/style';
+import StyleRoot from './components/style-root';
 import getState from './get-state';
 import keyframes from './keyframes';
 import {__clearStateForTests} from './resolve-styles';
@@ -13,6 +14,7 @@ function Radium(ComposedComponent: constructor) {
 Radium.Plugins = Plugins;
 Radium.PrintStyleSheet = PrintStyleSheet;
 Radium.Style = Style;
+Radium.StyleRoot = StyleRoot;
 Radium.getState = getState;
 Radium.keyframes = keyframes;
 Radium.__clearStateForTests = __clearStateForTests;

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -213,7 +213,8 @@ const _runPlugins = function({
     if (!styleKeeper) {
       throw new Error(
         'To use plugins requiring `addCSS` (e.g. keyframes, media queries), ' +
-          'please add `isRoot: true` to your root component\'s Radium config.',
+          'please wrap your application in the StyleRoot component. Component ' +
+          'name: `' + componentName + '`.',
       );
     }
 


### PR DESCRIPTION
`isRoot` had the odd behavior that it wrapped its contents in a div. Instead, make the “style root” a separate, explicit component.

Definitely open to feedback about the name!