### PR TITLE
Fix two minor bugs

### DIFF
--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -287,7 +287,7 @@ describe('Radium blackbox tests', () => {
   it('resolves styles if an element has element children and spreads props', () => {
     @Radium
     class Inner extends Component {
-      static propTypes = { children: PropTypes.node }
+      static propTypes = { children: PropTypes.node };
       render() {
         return (
           <div {...this.props} style={[{color: 'blue'}, {background: 'red'}]}>

--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -13,6 +13,8 @@ export default class StyleSheet extends Component {
     super(...arguments);
 
     this.state = this._getCSSState();
+
+    this._onChange = this._onChange.bind(this);
   }
 
   componentDidMount() {


### PR DESCRIPTION
- Bind the private method `_onChange()` to the class instance in `stylesheet.js`. This does, however, introduce a new bug if you're using react-router but I couldn't get to the bottom of it. The error reads: `Cannot update during an existing state transition`.
- Add missing semicolon to static member (caused an error) `inside radium-test.js`