### PR TITLE
Do not reprocess children's style if they are Radium-enhanced components themselves

### DIFF
--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -56,6 +56,8 @@ export default function enhanceWithRadium(
     _radiumMouseUpListener: {remove: () => void};
     _radiumIsMounted: bool;
 
+    static __isRadiumEnhanced = true;
+
     constructor() {
       super(...arguments);
 

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -56,7 +56,7 @@ export default function enhanceWithRadium(
     _radiumMouseUpListener: {remove: () => void};
     _radiumIsMounted: bool;
 
-    static __isRadiumEnhanced = true;
+    static _isRadiumEnhanced = true;
 
     constructor() {
       super(...arguments);

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -62,17 +62,26 @@ const _resolveChildren = function({
     };
   }
 
+  const shouldResolveStyles = function(element) {
+    return (element.type && !element.type.__isRadiumEnhanced);
+  };
+
   if (React.Children.count(children) === 1 && children.type) {
     // If a React Element is an only child, don't wrap it in an array for
     // React.Children.map() for React.Children.only() compatibility.
     const onlyChild = React.Children.only(children);
-    return resolveStyles(component, onlyChild, config, existingKeyMap);
+
+    if (shouldResolveStyles(onlyChild)) {
+      return resolveStyles(component, onlyChild, config, existingKeyMap);
+    } else {
+      return onlyChild;
+    }
   }
 
   return React.Children.map(
     children,
     function(child) {
-      if (React.isValidElement(child)) {
+      if (React.isValidElement(child) && shouldResolveStyles(child)) {
         return resolveStyles(component, child, config, existingKeyMap);
       }
 


### PR DESCRIPTION
Hey guys, at try.com we're using Radium on many low-level components (namely, a View wrapper which is a kind of smart component around div, adding flex capabilities and many other things), and we've noticed poor performances when there's successive re-renders (even though all of our components are Pure and we use immutable flux stores)

Our tree consists of a lot of View inside other View (makes sense right, since this is the equivalent of div for us), and so, I discovered that the way the mapping of the children is done atm is making these components re-process their styles, even though they were going to process it anyway because they're all Radium-enhanced components.

This commit makes dramatic improvements in our frame rate.

Does that make sense? Is there something I'm not seeing/not thinking of?

Cheers! We love Radium :)