### PR TITLE
[Prefix] Add an option to prefix for all user agent

### DIFF
--- a/src/__tests__/style-component-test.js
+++ b/src/__tests__/style-component-test.js
@@ -50,6 +50,25 @@ describe('<Style> component', () => {
     `);
   });
 
+  it('add all the prefixes when we ask for', () => {
+    const output = TestUtils.renderIntoDocument(
+      <Style
+        radiumConfig={{userAgent: 'all'}}
+        rules={{div: {transform: 'rotate(90)'}}}
+      />
+    );
+
+    const style = getElement(output, 'style');
+    expectCSS(style, `
+      div{
+        transform:rotate(90);
+        -webkit-transform:rotate(90);
+        -moz-transform:rotate(90);
+        -ms-transform:rotate(90);
+      }
+    `);
+  });
+
   it('adds scopeSelector to each selector', () => {
     const output = TestUtils.renderIntoDocument(
       <Style

--- a/src/prefixer.js
+++ b/src/prefixer.js
@@ -47,7 +47,14 @@ function getPrefixer(userAgent: ?string): InlineStylePrefixer {
   }
 
   if (!_cachedPrefixer || actualUserAgent !== _lastUserAgent) {
-    _cachedPrefixer = new InlineStylePrefixer({userAgent: actualUserAgent});
+    if (actualUserAgent === 'all') {
+      _cachedPrefixer = {
+        prefix: InlineStylePrefixer.prefixAll,
+        prefixedKeyframes: 'keyframes'
+      };
+    } else {
+      _cachedPrefixer = new InlineStylePrefixer({ userAgent: actualUserAgent });
+    }
     _lastUserAgent = actualUserAgent;
   }
   return _cachedPrefixer;


### PR DESCRIPTION
My use case for this, is to prefix for all user agent on the server side
and only for the browser agent on the client side. As pointed out here https://github.com/facebook/react/issues/1979
I think that it's a very good trade-off.
This allow me to remove the user agent from the memoization I use on the `renderToString` method.

The test fails because of https://github.com/rofrischmann/inline-style-prefixer/issues/58.
I'm gonna address it.

Fix https://github.com/FormidableLabs/radium/issues/546.