### PR TITLE
Add TestMode

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,6 +12,7 @@
 - [Plugins](#plugins)
 - [Style Component](#style-component)
 - [StyleRoot Component](#styleroot-component)
+- [TestMode](#testmode)
 
 
 ## Sample Style Object
@@ -546,3 +547,11 @@ class App extends React.Component {
   }
 }  
 ```
+
+## TestMode
+
+Directly off the main Radium object you can access `TestMode`, used to control internal Radium state and behavior during tests. It is only available in non-production builds.
+
+- `Radium.TestMode.clearState()` - clears the global Radium state, currently only the cache of media query listeners.
+- `Radium.TestMode.enable()` - enables "test mode", which doesn’t throw or warn as much. Currently it just doesn’t throw when using addCSS without StyleRoot.
+- `Radium.TestMode.disable()` - disables "test mode"

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Style from './components/style';
 import StyleRoot from './components/style-root';
 import getState from './get-state';
 import keyframes from './keyframes';
-import {__clearStateForTests} from './resolve-styles';
+import {__clearStateForTests, __setTestMode} from './resolve-styles';
 
 function Radium(ComposedComponent: constructor) {
   return Enhancer(ComposedComponent);
@@ -15,6 +15,13 @@ Radium.Style = Style;
 Radium.StyleRoot = StyleRoot;
 Radium.getState = getState;
 Radium.keyframes = keyframes;
-Radium.__clearStateForTests = __clearStateForTests;
+
+if (process.env.NODE_ENV !== 'production') {
+  Radium.TestMode = {
+    clearState: __clearStateForTests,
+    disable: __setTestMode.bind(null, false),
+    enable: __setTestMode.bind(null, true)
+  };
+}
 
 export default Radium;

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -220,6 +220,10 @@ const _runPlugins = function({
     const styleKeeper = component._radiumStyleKeeper ||
       component.context._radiumStyleKeeper;
     if (!styleKeeper) {
+      if (__isTestModeEnabled) {
+        return {remove() {}};
+      }
+
       throw new Error(
         'To use plugins requiring `addCSS` (e.g. keyframes, media queries), ' +
           'please wrap your application in the StyleRoot component. Component ' +
@@ -357,8 +361,14 @@ resolveStyles = function(
 };
 
 // Only for use by tests
-resolveStyles.__clearStateForTests = function() {
-  globalState = {};
-};
+let __isTestModeEnabled = false;
+if (process.env.NODE_ENV !== 'production') {
+  resolveStyles.__clearStateForTests = function() {
+    globalState = {};
+  };
+  resolveStyles.__setTestMode = function(isEnabled) {
+    __isTestModeEnabled = isEnabled;
+  };
+}
 
 export default resolveStyles;


### PR DESCRIPTION
Add a `TestMode` section off of `Radium`, only accessible in non-production
builds. It has three methods:
- `clearState` - clears the global radium state, only the cache of
media query listeners at this point
- `enable` - enables TestMode, which doesn’t throw or warn as much
(right now, it just doesn’t throw when using addCSS without StyleRoot)
- `disable` - disabled TestMode

Fixes #529