### PR TITLE
Fix media query sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "babel-preset-stage-1": "^6.3.13",
     "exenv": "^1.2.0",
     "inline-style-prefixer": "^0.6.2",
-    "rimraf": "^2.4.0"
+    "rimraf": "^2.4.0",
+    "sort-media-queries": "^0.2.2"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",

--- a/src/__tests__/media-query-test.js
+++ b/src/__tests__/media-query-test.js
@@ -274,7 +274,7 @@ describe('Media query tests', () => {
     const span = document.getElementsByTagName('span')[0];
     const computedStyle = window.getComputedStyle(span);
 
-    expectColor(computedStyle.getPropertyValue('color'), 'white');
+    expectColor(computedStyle.getPropertyValue('color'), 'blue');
   });
 
   it('doesn\'t add className if no media styles', () => {

--- a/src/style-keeper.js
+++ b/src/style-keeper.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import smq from 'sort-media-queries';
+
 export default class StyleKeeper {
   _userAgent: string;
   _listeners: Array<() => void>;
@@ -43,7 +45,7 @@ export default class StyleKeeper {
   }
 
   getCSS(): string {
-    return Object.keys(this._cssSet).join('\n');
+    return smq(Object.keys(this._cssSet)).join('\n');
   }
 
   _emitChange() {


### PR DESCRIPTION
In [radium-grid](https://github.com/FormidableLabs/radium-grid) we're still running into media query ordering issues. This PR appears to sort them out.

@ianobermiller would you mind looking at [this test?](https://github.com/FormidableLabs/radium/blob/master/src/__tests__/media-query-test.js#L247)
As far as I can tell, the color to expect is blue instead of white, assuming that both the 10px and 20px media queries match. Is this the right behavior?