### PR TITLE
Accept other StyleKeepers

### DIFF
--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -2,7 +2,6 @@
 
 import {Component, PropTypes} from 'react';
 
-import StyleKeeper from './style-keeper.js';
 import resolveStyles from './resolve-styles.js';
 
 const KEYS_TO_IGNORE_WHEN_COPYING_PROPERTIES = [
@@ -152,13 +151,21 @@ export default function enhanceWithRadium(
   RadiumEnhancer.contextTypes = {
     ...RadiumEnhancer.contextTypes,
     _radiumConfig: PropTypes.object,
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+    _radiumStyleKeeper: PropTypes.shape({
+      subscribe: PropTypes.func,
+      addCSS: PropTypes.func,
+      getCSS: PropTypes.func
+    })
   };
 
   RadiumEnhancer.childContextTypes = {
     ...RadiumEnhancer.childContextTypes,
     _radiumConfig: PropTypes.object,
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+    _radiumStyleKeeper: PropTypes.shape({
+      subscribe: PropTypes.func,
+      addCSS: PropTypes.func,
+      getCSS: PropTypes.func
+    })
   };
 
   return RadiumEnhancer;


### PR DESCRIPTION
Yo! Thank you for making Radium :D

I'm using Radium to create a UI library. Using the enhancer on the UI components, though, causes a problem with context. The context type is looking for an instance of its *own* package's `StyleKeeper`. However the `<StyleRoot>` in my project is passing down the project's `StyleKeeper`.

I changed the enhancer to accept the interface of the `StyleKeeper`, rather than an instance of the actual `StyleKeeper`.

Thanks! ^^