### PR TITLE
Handle (active) states for touch devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-preset-stage-1": "^6.3.13",
     "exenv": "^1.2.0",
     "inline-style-prefixer": "^0.6.2",
+    "mobile-detect": "^1.3.1",
     "rimraf": "^2.4.0"
   },
   "devDependencies": {

--- a/src/plugins/mouse-up-listener.js
+++ b/src/plugins/mouse-up-listener.js
@@ -1,5 +1,9 @@
 /* @flow */
 
+import MobileDetect from 'mobile-detect';
+
+const isMobile = !!(new MobileDetect(window.navigator.userAgent)).mobile();
+
 const _callbacks = [];
 let _mouseUpListenerIsActive = false;
 
@@ -15,7 +19,8 @@ const subscribe = function(callback: () => void): {remove: () => void} {
   }
 
   if (!_mouseUpListenerIsActive) {
-    window.addEventListener('mouseup', _handleMouseUp);
+    // On mobile listen to touch end instead of mouse up.
+    window.addEventListener(isMobile ? 'touchend' : 'mouseup', _handleMouseUp);
     _mouseUpListenerIsActive = true;
   }
 
@@ -25,7 +30,7 @@ const subscribe = function(callback: () => void): {remove: () => void} {
       _callbacks.splice(index, 1);
 
       if (_callbacks.length === 0 && _mouseUpListenerIsActive) {
-        window.removeEventListener('mouseup', _handleMouseUp);
+        window.removeEventListener(isMobile ? 'touchend' : 'mouseup', _handleMouseUp);
         _mouseUpListenerIsActive = false;
       }
     }
@@ -33,6 +38,7 @@ const subscribe = function(callback: () => void): {remove: () => void} {
 };
 
 export default {
+  useTouchEvents: isMobile,
   subscribe: subscribe,
   __triggerForTests: _handleMouseUp
 };

--- a/src/plugins/resolve-interaction-styles-plugin.js
+++ b/src/plugins/resolve-interaction-styles-plugin.js
@@ -43,12 +43,23 @@ const resolveInteractionStyles = function(config: PluginConfig): PluginResult {
   }
 
   if (style[':active']) {
-    const existingOnMouseDown = props.onMouseDown;
-    newProps.onMouseDown = function(e) {
-      existingOnMouseDown && existingOnMouseDown(e);
-      newComponentFields._lastMouseDown = Date.now();
-      setState(':active', 'viamousedown');
-    };
+    // On mobile listen to touch events to determine whether or not to apply the active styles.
+    if (MouseUpListener.useTouchEvents) {
+      const existingOnTouchStart = props.onTouchStart;
+      newProps.onTouchStart = function(e) {
+        existingOnTouchStart && existingOnTouchStart(e);
+        newComponentFields._lastTouchStart = Date.now();
+        setState(':active', 'viatouchstart');
+      };
+    } else {
+      // Otherwise, listen to mouse down.
+      const existingOnMouseDown = props.onMouseDown;
+      newProps.onMouseDown = function(e) {
+        existingOnMouseDown && existingOnMouseDown(e);
+        newComponentFields._lastMouseDown = Date.now();
+        setState(':active', 'viamousedown');
+      };
+    }
 
     const existingOnKeyDown = props.onKeyDown;
     newProps.onKeyDown = function(e) {
@@ -89,7 +100,8 @@ const resolveInteractionStyles = function(config: PluginConfig): PluginResult {
     newComponentFields._radiumMouseUpListener = MouseUpListener.subscribe(
       () => {
         Object.keys(getComponentField('state')._radiumStyleState).forEach(key => {
-          if (getState(':active', key) === 'viamousedown') {
+          if (getState(':active', key) === 'viamousedown' ||
+            getState(':active', key) === 'viatouchstart') {
             setState(':active', false, key);
           }
         });


### PR DESCRIPTION
Currently :active styles do not work on mobile because they are based on mousedown and mouseup events.
If on mobile use touchstart and touchend instead.

Fixes https://github.com/FormidableLabs/radium/issues/63