### PR TITLE
Add support to 'disabled' prop

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -49,6 +49,7 @@ class TwoSquares extends React.Component {
       <div>
         <div key="one" style={[squareStyles.both, squareStyles.one]} />
         <div key="two" style={[squareStyles.both, squareStyles.two]} />
+        <div key="three" disabled style={[squareStyles.both, squareStyles.three]} />
         <div style={{clear: 'both'}} />
       </div>
     )
@@ -188,6 +189,14 @@ var squareStyles = {
   two: {
     ':hover': {
       background: 'red',
+    }
+  },
+  three: {
+    ':hover': {
+      background: 'yellow'
+    }
+    , ':disabled': {
+      background: 'red'
     }
   }
 };

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -47,9 +47,9 @@ class TwoSquares extends React.Component {
   render () {
     return (
       <div>
-        <div key="one" style={[squareStyles.both, squareStyles.one]} />
-        <div key="two" style={[squareStyles.both, squareStyles.two]} />
-        <div key="three" disabled style={[squareStyles.both, squareStyles.three]} />
+        <div key="one" style={[squareStyles.all, squareStyles.one]} />
+        <div key="two" style={[squareStyles.all, squareStyles.two]} />
+        <div key="three" disabled style={[squareStyles.all, squareStyles.three]} />
         <div style={{clear: 'both'}} />
       </div>
     )
@@ -174,7 +174,7 @@ var App = React.createClass({
 App = Radium(App);
 
 var squareStyles = {
-  both: {
+  all: {
     background: 'black',
     border: 'solid 1px white',
     float: 'left',
@@ -194,8 +194,8 @@ var squareStyles = {
   three: {
     ':hover': {
       background: 'yellow'
-    }
-    , ':disabled': {
+    },
+    ':disabled': {
       background: 'red'
     }
   }

--- a/src/__tests__/resolve-styles-test.js
+++ b/src/__tests__/resolve-styles-test.js
@@ -621,7 +621,7 @@ describe('resolveStyles', function() {
       });
     });
   });
-  
+
   describe('disabled', function() {
     it('discards interaction styles if element is disabled', function() {
       const component = genComponent();
@@ -647,7 +647,7 @@ describe('resolveStyles', function() {
       expect(children[0].props.style).to.be.undefined;
       expect(children[1].props.style.background).to.equal('blue');
     });
-    
+
     it('styles according to :disabled style if element is disabled', function() {
       const component = genComponent();
       const style = {background: 'blue'};

--- a/src/__tests__/resolve-styles-test.js
+++ b/src/__tests__/resolve-styles-test.js
@@ -621,6 +621,59 @@ describe('resolveStyles', function() {
       });
     });
   });
+  
+  describe('disabled', function() {
+    it('discards interaction styles if element is disabled', function() {
+      const component = genComponent();
+      const style = {background: 'blue'};
+      style[':hover'] = {background: 'red'};
+
+      const renderedElement = (
+        <div>
+          <div ref="foo" />
+          <div ref="bar" disabled style={style} />
+        </div>
+      );
+
+      let result = resolveStyles(component, renderedElement);
+      let children = getChildrenArray(result.props.children);
+      expect(children[0].props.style).to.be.undefined;
+      expect(children[1].props.style.background).to.equal('blue');
+
+      children[1].props.onMouseEnter();
+
+      result = resolveStyles(component, renderedElement);
+      children = getChildrenArray(result.props.children);
+      expect(children[0].props.style).to.be.undefined;
+      expect(children[1].props.style.background).to.equal('blue');
+    });
+    
+    it('styles according to :disabled style if element is disabled', function() {
+      const component = genComponent();
+      const style = {background: 'blue'};
+      style[':hover'] = {background: 'red'};
+      style[':disabled'] = {background: 'yellow'};
+
+      const renderedElement = (
+        <div>
+          <div ref="foo" />
+          <div ref="bar" disabled style={style} />
+        </div>
+      );
+
+      let result = resolveStyles(component, renderedElement);
+      let children = getChildrenArray(result.props.children);
+      expect(children[0].props.style).to.be.undefined;
+      expect(children[1].props.style.background).to.equal('yellow');
+
+      children[1].props.onMouseEnter();
+
+      result = resolveStyles(component, renderedElement);
+      children = getChildrenArray(result.props.children);
+      expect(children[0].props.style).to.be.undefined;
+      expect(children[1].props.style.background).to.equal('yellow');
+    });
+  });
 
   /* eslint-disable no-console */
   describe('warnings', function() {

--- a/src/plugins/resolve-interaction-styles-plugin.js
+++ b/src/plugins/resolve-interaction-styles-plugin.js
@@ -98,7 +98,7 @@ const resolveInteractionStyles = function(config: PluginConfig): PluginResult {
   }
 
   // Merge the styles in the order they were defined
-  const interactionStyles = Object.keys(style)
+  const interactionStyles = props.disabled ? [style[':disabled']] : Object.keys(style)
     .filter(name => _isInteractiveStyleField(name) && getState(name))
     .map(name => style[name]);
 
@@ -107,7 +107,7 @@ const resolveInteractionStyles = function(config: PluginConfig): PluginResult {
   // Remove interactive styles
   newStyle = Object.keys(newStyle).reduce(
     (styleWithoutInteractions, name) => {
-      if (!_isInteractiveStyleField(name)) {
+      if (!_isInteractiveStyleField(name) && name !== ':disabled') {
         styleWithoutInteractions[name] = newStyle[name];
       }
       return styleWithoutInteractions;


### PR DESCRIPTION
Disabled elements will not react to interactions (hover/active/focus) and follow the `:disabled` pseudo-class style.

`<input disabled style={{':hover': ..., ':disabled': ...}}>`
