### PR TITLE
Feature: remove nested style objects

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -224,6 +224,7 @@ function ConfiguredRadium(component) {
       Radium.Plugins.resolveInteractionStyles,
       Radium.Plugins.keyframes,
       Radium.Plugins.visited,
+      Radium.Plugins.removeNestedStyles,
       Radium.Plugins.prefix,
       styleLogger,
       Radium.Plugins.checkProps,

--- a/src/__tests__/remove-nested-styles-test.js
+++ b/src/__tests__/remove-nested-styles-test.js
@@ -5,7 +5,7 @@ import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import {expectCSS, getElement} from 'test-helpers';
 
-describe('removeObjectStyles plugin tests', () => {
+describe('removeNestedStyles plugin tests', () => {
   it('removes nested style objects', () => {
     const ChildComponent = Radium(() =>
       <span style={{ color: 'red', foo: { color: 'blue' }}} />
@@ -20,5 +20,23 @@ describe('removeObjectStyles plugin tests', () => {
     const output = TestUtils.renderIntoDocument(<TestComponent />);
     const span = getElement(output, 'span');
     expect(span.style.foo).to.not.exist;
+  });
+
+  it('should not remove style objects that have a toString function defined', () => {
+    const styleObject = { color: 'blue' }
+    styleObject.toString = () => 'bar'
+    const ChildComponent = Radium(() =>
+      <span style={{ color: 'red', foo: styleObject }} />
+    );
+
+    const TestComponent = Radium(() =>
+      <StyleRoot>
+        <ChildComponent />
+      </StyleRoot>
+    );
+
+    const output = TestUtils.renderIntoDocument(<TestComponent />);
+    const span = getElement(output, 'span');
+    expect(span.style.foo).to.equal('bar');
   });
 });

--- a/src/__tests__/remove-nested-styles-test.js
+++ b/src/__tests__/remove-nested-styles-test.js
@@ -3,7 +3,7 @@
 import Radium, {StyleRoot} from 'index';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
-import {expectCSS, getElement} from 'test-helpers';
+import {getElement} from 'test-helpers';
 
 describe('removeNestedStyles plugin tests', () => {
   it('removes nested style objects', () => {
@@ -23,8 +23,8 @@ describe('removeNestedStyles plugin tests', () => {
   });
 
   it('should not remove style objects that have a toString function defined', () => {
-    const styleObject = { color: 'blue' }
-    styleObject.toString = () => 'bar'
+    const styleObject = { color: 'blue' };
+    styleObject.toString = () => 'bar';
     const ChildComponent = Radium(() =>
       <span style={{ color: 'red', foo: styleObject }} />
     );

--- a/src/__tests__/remove-object-styles-test.js
+++ b/src/__tests__/remove-object-styles-test.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/prop-types */
+
+import Radium, {StyleRoot} from 'index';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import {expectCSS, getElement} from 'test-helpers';
+
+describe('removeObjectStyles plugin tests', () => {
+  it('removes nested style objects', () => {
+    const ChildComponent = Radium(() =>
+      <span style={{ color: 'red', foo: { color: 'blue' }}} />
+    );
+
+    const TestComponent = Radium(() =>
+      <StyleRoot>
+        <ChildComponent />
+      </StyleRoot>
+    );
+
+    const output = TestUtils.renderIntoDocument(<TestComponent />);
+    const span = getElement(output, 'span');
+    expect(span.style.foo).to.not.exist;
+  });
+});

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -7,6 +7,7 @@ import checkPropsPlugin from './check-props-plugin';
 import keyframesPlugin from './keyframes-plugin';
 import mergeStyleArrayPlugin from './merge-style-array-plugin';
 import prefixPlugin from './prefix-plugin';
+import removeNestedStylesPlugin from './remove-nested-styles-plugin';
 import resolveInteractionStylesPlugin from './resolve-interaction-styles-plugin';
 import resolveMediaQueriesPlugin from './resolve-media-queries-plugin';
 import visitedPlugin from './visited-plugin';
@@ -94,6 +95,7 @@ export default {
   keyframes: keyframesPlugin,
   mergeStyleArray: mergeStyleArrayPlugin,
   prefix: prefixPlugin,
+  removeNestedStyles: removeNestedStylesPlugin,
   resolveInteractionStyles: resolveInteractionStylesPlugin,
   resolveMediaQueries: resolveMediaQueriesPlugin,
   visited: visitedPlugin

--- a/src/plugins/remove-nested-styles-plugin.js
+++ b/src/plugins/remove-nested-styles-plugin.js
@@ -7,7 +7,7 @@ export default function removeNestedStyles({
   style
 }: PluginConfig): PluginResult { // eslint-disable-line no-shadow
   const newStyle = Object.keys(style).reduce((newStyleInProgress, key) => {
-    let value = style[key];
+    const value = style[key];
     if (!isNestedStyle(value)) {
       newStyleInProgress[key] = value;
     }

--- a/src/plugins/remove-nested-styles-plugin.js
+++ b/src/plugins/remove-nested-styles-plugin.js
@@ -1,0 +1,20 @@
+/** @flow */
+
+import type {PluginConfig, PluginResult} from './index';
+
+export default function removeNestedStyles({
+  isNestedStyle,
+  style
+}: PluginConfig): PluginResult { // eslint-disable-line no-shadow
+  const newStyle = Object.keys(style).reduce((newStyleInProgress, key) => {
+    let value = style[key];
+    if (!isNestedStyle(value)) {
+      newStyleInProgress[key] = value;
+    }
+    return newStyleInProgress;
+  }, {});
+
+  return {
+    style: newStyle
+  };
+}

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -21,6 +21,7 @@ const DEFAULT_CONFIG = {
     Plugins.resolveInteractionStyles,
     Plugins.keyframes,
     Plugins.visited,
+    Plugins.removeNestedStyles,
     Plugins.prefix,
     Plugins.checkProps
   ]


### PR DESCRIPTION
This PR adds a plugin for removing nested style definitions. For some background have a look at #634 

Nested objects with a custom `toString` implementation are not removed.