### PR TITLE
quote values for content property

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+/*
+!/.babelrc
+!/dist
+!/lib
+!/src
+

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Following is a short technical explanation of Radium's inner workings:
   - If any of the handlers are triggered, e.g. by hovering, Radium calls `setState` to update a Radium-specific field on the components state object
   - On re-render, resolve any interactive styles that apply, e.g. `:hover`, by looking up the element's key or ref in the Radium-specific state
 
+## More with Radium
+
+You can find a list of other tools, components, and frameworks to help you build with Radium on our [wiki](https://github.com/FormidableLabs/radium/wiki). Contributions welcome!
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -205,7 +205,7 @@ var style = {
 };
 ```
 
-Radium will apply the correct styles for the currently active media queries. Top level CSS rules in your media queries will be converted to CSS and rendered in an actual `<style>` element with `!important` appended instead of being applied inline so they will work with server-side rendering. Note that you must add the `isRoot: true` config to your App component, e.g. `@Radium({isRoot: true})` to render the Radium stylesheet. Print styles will also work as normal, since they are rendered to CSS.
+Radium will apply the correct styles for the currently active media queries. Top level CSS rules in your media queries will be converted to CSS and rendered in an actual `<style>` element with `!important` appended instead of being applied inline so they will work with server-side rendering. Note that you must wrap your top-level component in the `<StyleRoot>` component to render the Radium stylesheet. Print styles will also work as normal, since they are rendered to CSS.
 
 ### Nested browser states
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "0.17.1",
   "description": "A set of tools to manage inline styles on React elements",
   "main": "lib/index.js",
-  "files": [
-    "dist",
-    "lib"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/formidablelabs/radium.git"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-flow-vars": "^0.4.0",
     "eslint-plugin-react": "^5.0.1",
     "express": "^4.13.3",
-    "express-http-proxy": "^0.6.0",
+    "express-http-proxy": "^0.7.0",
     "flow-bin": "^0.20.1",
     "in-publish": "^2.0.0",
     "inject-loader": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.0",
+    "babylon": "6.8.0",
     "chai": "^3.0.0",
     "color": "^0.11.1",
     "concurrently": "^1.0.0",

--- a/src/__tests__/style-component-test.js
+++ b/src/__tests__/style-component-test.js
@@ -34,6 +34,19 @@ describe('<Style> component', () => {
     `);
   });
 
+  it('quotes properties that need it', () => {
+    const output = TestUtils.renderIntoDocument(
+      <Style rules={{'div::before': {content: '*'}}} />
+    );
+
+    const style = getElement(output, 'style');
+    expectCSS(style, `
+      div::before {
+        content: "*";
+      }
+    `);
+  });
+
   it('can be configured standalone', () => {
     const output = TestUtils.renderIntoDocument(
       <Style

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -5,9 +5,14 @@ import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
 import mapObject from './map-object';
 import {getPrefixedStyle} from './prefixer';
 
+function quoteValueIfNeeded(property, value) {
+  const quotedProperties = ['content'];
+  return (quotedProperties.indexOf(property) >= 0) ? `"${value}"` : value;
+}
+
 function createMarkupForStyles(style: Object): string {
   return Object.keys(style).map(property => {
-    return property + ': ' + style[property] + ';';
+    return `${property}: ${quoteValueIfNeeded(property, style[property])};`;
   }).join('\n');
 }
 

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -6,6 +6,11 @@ import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
 import mapObject from './map-object';
 import {getPrefixedStyle} from './prefixer';
 
+function quoteValueIfNeeded(property, value) {
+  const quotedProperties = ['content'];
+  return (quotedProperties.indexOf(property) >= 0) ? `"${value}"` : value;
+}
+
 function createMarkupForStyles(style: Object): string {
   return Object.keys(style).map(property => {
     return `${property}: ${quoteValueIfNeeded(property, style[property])};`;

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -1,14 +1,10 @@
 /* @flow */
 
 import appendPxIfNeeded from './append-px-if-needed';
+import quoteValueIfNeeded from './quote-value-if-needed';
 import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
 import mapObject from './map-object';
 import {getPrefixedStyle} from './prefixer';
-
-function quoteValueIfNeeded(property, value) {
-  const quotedProperties = ['content'];
-  return (quotedProperties.indexOf(property) >= 0) ? `"${value}"` : value;
-}
 
 function createMarkupForStyles(style: Object): string {
   return Object.keys(style).map(property => {

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -6,11 +6,6 @@ import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
 import mapObject from './map-object';
 import {getPrefixedStyle} from './prefixer';
 
-function quoteValueIfNeeded(property, value) {
-  const quotedProperties = ['content'];
-  return (quotedProperties.indexOf(property) >= 0) ? `"${value}"` : value;
-}
-
 function createMarkupForStyles(style: Object): string {
   return Object.keys(style).map(property => {
     return `${property}: ${quoteValueIfNeeded(property, style[property])};`;

--- a/src/quote-value-if-needed.js
+++ b/src/quote-value-if-needed.js
@@ -1,5 +1,7 @@
+/* @flow */
+
 const quotedProperties = ['content'];
 
-export default function quoteValueIfNeeded(property, value) {
+export default function quoteValueIfNeeded(property: string, value: any): string {
   return (quotedProperties.indexOf(property) >= 0) ? `"${value}"` : value;
 }

--- a/src/quote-value-if-needed.js
+++ b/src/quote-value-if-needed.js
@@ -1,0 +1,5 @@
+const quotedProperties = ['content'];
+
+export default function quoteValueIfNeeded(property, value) {
+  return (quotedProperties.indexOf(property) >= 0) ? `"${value}"` : value;
+}


### PR DESCRIPTION
When the `Style` component is used, one ought to be able to specify a rule like:
```javascript
'a:visited::before': {
  content: '√'
}
```

In master, though, this gets compiled as:

```css
a:visited::before {
  content: √;
}
```

The missing quotes prevent the `content` property from working correctly. This PR adds the missing quotes, so you'll get this:

```css
a:visited::before {
  content: "√";
}
```