### PR TITLE
Pin babylon 6.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-preset-es2015-loose": "^6.1.3",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.3.13",
+    "babylon": "6.8.0",
     "exenv": "^1.2.0",
     "inline-style-prefixer": "^1.0.3",
     "rimraf": "^2.4.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "babel-preset-es2015-loose": "^6.1.3",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.3.13",
-    "babylon": "6.8.0",
     "exenv": "^1.2.0",
     "inline-style-prefixer": "^1.0.3",
     "rimraf": "^2.4.0"
@@ -54,6 +53,7 @@
   "devDependencies": {
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.0",
+    "babylon": "6.8.0",
     "chai": "^3.0.0",
     "color": "^0.11.1",
     "concurrently": "^1.0.0",


### PR DESCRIPTION
@alexlande @ianobermiller It looks like babel-eslint is having some trouble with babylon 6.8.1 and pinning to 6.8.0 fixes the build issue in #727 for now.