### PR TITLE
Update travis and appveyor node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - "0.10"
   - "0.12"
-  - "iojs"
+  - "4.2"
+  - "5.0"
 
 # Use container-based Travis infrastructure.
 sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 # Test against this version of Node.js
 environment:
   matrix:
-    - nodejs_version: 0.10
     - nodejs_version: 0.12
+    - nodejs_version: 4.2
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
@alexlande This knocks out the small chore at #729. Do you think we need to add 5.0 for appveyor?