### PR TITLE
Fix unused property warning in StyleRoot

### DIFF
--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -31,8 +31,13 @@ class StyleRoot extends Component {
   }
 
   render() {
+    /* eslint-disable no-unused-vars */
+    // Remove prop before being applied to DOM Node
+    // As of React v15.2.0 - Unknown props issue warning
+    const { _radiumDidResolveStyles, ...additionalProps } = this.props;
+    /* eslint-enable */
     return (
-      <div {...this.props}>
+      <div {...additionalProps}>
         {this.props.children}
         <StyleSheet />
       </div>


### PR DESCRIPTION
As of React v15.2.0(https://github.com/facebook/react/pull/6800) - React issues warnings for unknown properties passed to DOM nodes. This should fix the warning when using the StyleRoot component.

I haven't tested this but it seems reasonable.

Fixes #759