### PR TITLE
Unpin babylon

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "babel-eslint": "^6.1.0",
     "babel-loader": "^6.2.0",
-    "babylon": "6.8.0",
     "chai": "^3.0.0",
     "color": "^0.11.2",
     "concurrently": "^1.0.0",


### PR DESCRIPTION
Babylon has released a few minor versions since their regression in
6.8.1, so there's no longer any need to pin to the previous version.

/cc @jmcriffey @ianobermiller 