### PR TITLE
Better check for stateless component

### DIFF
--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -658,6 +658,11 @@ describe('Radium blackbox tests', () => {
         {props.children}
       </div>
     );
+
+    // Babel is forced to use regular functions when defining arrow functions.
+    // Arrow functions should not technically have prototypes,
+    // so remove it here to make sure Radium doesn't fail with real arrow functions.
+    MyStatelessComponent.prototype = undefined;
     MyStatelessComponent = Radium(MyStatelessComponent);
 
     const output = TestUtils.renderIntoDocument(

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -27,6 +27,10 @@ function copyProperties(source, target) {
   });
 }
 
+function isStateless(component: Function): boolean {
+  return !!(!component.render && !(component.prototype && component.prototype.render));
+}
+
 export default function enhanceWithRadium(
   configOrComposedComponent: Class<any> | constructor | Function | Object,
   config?: Object = {},
@@ -42,7 +46,7 @@ export default function enhanceWithRadium(
   let ComposedComponent: constructor = component;
 
   // Handle stateless components
-  if (!ComposedComponent.render && !ComposedComponent.prototype.render) {
+  if (isStateless(ComposedComponent)) {
     ComposedComponent = class extends Component {
       render() {
         return component(this.props, this.context);

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -28,7 +28,7 @@ function copyProperties(source, target) {
 }
 
 function isStateless(component: Function): boolean {
-  return !!(!component.render && !(component.prototype && component.prototype.render));
+  return !component.render && !(component.prototype && component.prototype.render);
 }
 
 export default function enhanceWithRadium(


### PR DESCRIPTION
@alexlande Addresses #762. 

As things currently stand, our stateless component detection usually works because Babel uses regular functions to compile arrows functions. This causes trouble if a user is targeting an environment that supports real arrow functions. This PR should address that case.