### PR TITLE
Add docs to npm bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 /*
 !/.babelrc
 !/dist
+!/docs
 !/lib
 !/src
-

--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,4 @@
 !/dist
 !/docs
 !/lib
-!/README.md
 !/src

--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,5 @@
 !/dist
 !/docs
 !/lib
+!/README.md
 !/src

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+### Overview
+
+The `radium-docs` [documentation site](http://formidable.com/open-source/radium-test/) source lives here in `/docs`. The `docs/**/docs.js` components are imported into `radium-docs` and deployed from there.
+
+### Deployment
+
+Submit a pull request to `master`. Once it is merged you will need to run `update-project` from within `radium-docs` and merge into `master`. A new push to `master` in `radium-docs` will trigger a deployment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+### Overview
+
+The `radium-docs` [documentation site](http://formidable.com/open-source/radium-test/) source lives here in `/docs`. The `docs/**/docs.js` components are imported into `radium-docs` and deployed from there.
+
+### Deployment
+
+Submit a pull request to `master`, and once it's merged, `radium-docs` will need to run `update-project` and merge into `master`. A new push to `master` in `radium-docs` will trigger a deployment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,0 @@
-### Overview
-
-The `radium-docs` [documentation site](http://formidable.com/open-source/radium-test/) source lives here in `/docs`. The `docs/**/docs.js` components are imported into `radium-docs` and deployed from there.
-
-### Deployment
-
-Submit a pull request to `master`, and once it's merged, `radium-docs` will need to run `update-project` and merge into `master`. A new push to `master` in `radium-docs` will trigger a deployment.


### PR DESCRIPTION
This will include the `/docs` directory and the `readme` in the npm bundle. Doing this allows us to create a separate documentation site that includes the latest documentation notes.

https://github.com/FormidableLabs/radium-docs/issues/11

cc @paulathevalley @alexlande 