### PR TITLE
Breaking revert content quoting

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -525,6 +525,11 @@ A string that any included selectors in `rules` will be appended to. Use to scop
 </div>
 ```
 
+### Notes
+
+Some style properties, like [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content), allow quoted strings or keywords as values. Because all non-numerical property values are written
+as strings in Radium style objects, you must explicitly add quotes to string value for these properties: `content: "'Hello World!'"`.
+
 ## StyleRoot Component
 
 _Props: Accepts all props valid on `div` and optional `radiumConfig`_

--- a/src/__tests__/style-component-test.js
+++ b/src/__tests__/style-component-test.js
@@ -34,19 +34,6 @@ describe('<Style> component', () => {
     `);
   });
 
-  it('quotes properties that need it', () => {
-    const output = TestUtils.renderIntoDocument(
-      <Style rules={{'div::before': {content: '*'}}} />
-    );
-
-    const style = getElement(output, 'style');
-    expectCSS(style, `
-      div::before {
-        content: "*";
-      }
-    `);
-  });
-
   it('can be configured standalone', () => {
     const output = TestUtils.renderIntoDocument(
       <Style

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -1,14 +1,13 @@
 /* @flow */
 
 import appendPxIfNeeded from './append-px-if-needed';
-import quoteValueIfNeeded from './quote-value-if-needed';
 import camelCasePropsToDashCase from './camel-case-props-to-dash-case';
 import mapObject from './map-object';
 import {getPrefixedStyle} from './prefixer';
 
 function createMarkupForStyles(style: Object): string {
   return Object.keys(style).map(property => {
-    return `${property}: ${quoteValueIfNeeded(property, style[property])};`;
+    return property + ': ' + style[property] + ';';
   }).join('\n');
 }
 

--- a/src/quote-value-if-needed.js
+++ b/src/quote-value-if-needed.js
@@ -1,7 +1,0 @@
-/* @flow */
-
-const quotedProperties = ['content'];
-
-export default function quoteValueIfNeeded(property: string, value: any): string {
-  return (quotedProperties.indexOf(property) >= 0) ? `"${value}"` : value;
-}


### PR DESCRIPTION
This reverts our `content` quote change because it broke behavior for keywords. Annoying, but luckily you can still use `content` with strings by explicitly double-quoting your values.

Resolves #780 