### PR TITLE
Stop passing radiumConfig prop to div

### DIFF
--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -31,8 +31,13 @@ class StyleRoot extends Component {
   }
 
   render() {
+    /* eslint-disable no-unused-vars */
+    // Pass down all props except config to the rendered div.
+    const {radiumConfig, ...otherProps} = this.props;
+    /* eslint-enable no-unused-vars */
+
     return (
-      <div {...this.props}>
+      <div {...otherProps}>
         {this.props.children}
         <StyleSheet />
       </div>


### PR DESCRIPTION
Thanks to @doctyper for pointing this one out! One last potential unused props warning in React 15.2.