### PR TITLE
Remove lolex dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "karma-sinon-chai": "^1.2.1",
     "karma-webpack": "^1.7.0",
     "lodash.merge": "^4.0.2",
-    "lolex": "^1.4.0",
     "mocha": "^3.0.2",
     "node-libs-browser": "^0.5.2",
     "nodemon": "^1.4.1",


### PR DESCRIPTION
We had to add an explicit lolex dependency due to an issue in karma-sinon-chai, but it's been fixed since so we don't need to bother with it.