### PR TITLE
Drop Node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "0.12"
   - "4.2"
   - "5.0"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 # Test against this version of Node.js
 environment:
   matrix:
-    - nodejs_version: 0.12
     - nodejs_version: 4.2
 
 # Install scripts. (runs after repo cloning)


### PR DESCRIPTION
Following Victory's lead (https://github.com/FormidableLabs/victory/pull/302). An increasing number of our dependencies don't support Node 0.12 anymore, not worth the headache.