### PR TITLE
Handle empty strings and nulls in style objects

### DIFF
--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -7,7 +7,9 @@ import {getPrefixedStyle} from './prefixer';
 
 function createMarkupForStyles(style: Object): string {
   return Object.keys(style).map(property => {
-    return property + ': ' + style[property] + ';';
+    if (!(property === '' || property === null)) {
+      return property + ': ' + style[property] + ';';
+    } else return '';
   }).join('\n');
 }
 


### PR DESCRIPTION
Currently, React skips over keys in style objects with null or ''
values. This brings Radium's behavior in line with React. The current
behavior will create stylesheets that contain (e.g) "display:null;"
which is at best eyebrow-raising.