### PR TITLE
Switch StyleKeeper PropType check from instanceof to duck-typing

### DIFF
--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -6,7 +6,7 @@ import StyleKeeper from '../style-keeper';
 
 export default class StyleSheet extends Component {
   static contextTypes = {
-    _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
+    _radiumStyleKeeper: StyleKeeper.isStyleKeeper
   };
 
   constructor() {

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -156,13 +156,13 @@ export default function enhanceWithRadium(
   RadiumEnhancer.contextTypes = {
     ...RadiumEnhancer.contextTypes,
     _radiumConfig: PropTypes.object,
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+    _radiumStyleKeeper: StyleKeeper.isStyleKeeper
   };
 
   RadiumEnhancer.childContextTypes = {
     ...RadiumEnhancer.childContextTypes,
     _radiumConfig: PropTypes.object,
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
+    _radiumStyleKeeper: StyleKeeper.isStyleKeeper
   };
 
   return RadiumEnhancer;

--- a/src/style-keeper.js
+++ b/src/style-keeper.js
@@ -49,4 +49,29 @@ export default class StyleKeeper {
   _emitChange() {
     this._listeners.forEach(listener => listener());
   }
+
+  // React PropType validator function
+  static isStyleKeeper(props, propName, componentName) {
+    const msg = [
+      `Invalid prop ${propName} supplied to ${componentName}.`,
+      'Must be an instance of radium.StyleKeeper'
+    ].join(' ');
+
+    const requiredShape = {
+      subscribe: 'function',
+      addCSS: 'function',
+      getCSS: 'function',
+      _emitChange: 'function'
+    };
+
+    const shape = props[propName];
+
+    if (!Object.keys(requiredShape).every(key => {
+      // console.warn(key, typeof shape[key], requiredShape[key]);
+      return typeof shape[key] === requiredShape[key];
+    })) {
+      // console.error(shape, requiredShape)
+      throw new Error(msg);
+    }
+  }
 }


### PR DESCRIPTION
This PR Fixes #575

The use case that spawns this problem is having two different repositories,  both with instances of Radium, where one repository uses a React component from the other.

When this happens the PropType check for StyleKeeper fails on checking for identical instances, apparently because there is one instance of Radium from one repository which wants to attach components to the style root of the second repository.

This pull request adds a static proptype validator function `isStyleKeeper` to `StyleKeeper`, which compares instances using duck-typing rather than instance comparison.

The path has been verified to work when radium is linked into both repositories and components are used across them.

I have run linting, tests and flow.
