### PR TITLE
fix: Use React.PureComponent to avoid unnecessary rendering

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,7 @@
 .*/node_modules/babel-loader/.*
 .*/node_modules/flow-bin/.*
 .*/node_modules/inline-style-prefixer/.*
+.*/node_modules/invariant/.*
 .*/node_modules/mkdirp/.*
 .*/node_modules/nodemon/.*
 .*/node_modules/react-hot-loader/.*

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.3.13",
     "exenv": "^1.2.0",
-    "inline-style-prefixer": "^2.0.1",
+    "inline-style-prefixer": ">2.0.0 <2.0.5",
     "rimraf": "^2.4.0"
   },
   "devDependencies": {
@@ -78,9 +78,9 @@
     "nodemon": "^1.4.1",
     "object-assign": "^4.0.1",
     "phantomjs-prebuilt": "^2.1.7",
-    "react": "^15.0.1",
-    "react-addons-test-utils": "^15.0.1",
-    "react-dom": "^15.2.0",
+    "react": "^15.3.0",
+    "react-addons-test-utils": "^15.3.0",
+    "react-dom": "^15.3.0",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.9.11",

--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, {Component, PropTypes} from 'react';
+import React, {PureComponent, PropTypes} from 'react';
 
 import Enhancer from '../enhancer';
 import StyleKeeper from '../style-keeper';
@@ -19,7 +19,7 @@ function _getStyleKeeper(instance): StyleKeeper {
   return instance._radiumStyleKeeper;
 }
 
-class StyleRoot extends Component {
+class StyleRoot extends PureComponent {
   constructor() {
     super(...arguments);
 

--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 
 import StyleKeeper from '../style-keeper';
 
-export default class StyleSheet extends Component {
+export default class StyleSheet extends PureComponent {
   static contextTypes = {
     _radiumStyleKeeper: React.PropTypes.instanceOf(StyleKeeper)
   };

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -2,24 +2,22 @@
 
 import cssRuleSetToString from '../css-rule-set-to-string';
 
-import React, {PropTypes} from 'react';
+import React, {PropTypes, PureComponent} from 'react';
 
-const Style = React.createClass({
-  propTypes: {
+class Style extends PureComponent {
+  static propTypes = {
     radiumConfig: PropTypes.object,
     rules: PropTypes.object,
     scopeSelector: PropTypes.string
-  },
+  };
 
-  contextTypes: {
+  static contextTypes = {
     _radiumConfig: PropTypes.object
-  },
+  };
 
-  getDefaultProps(): {scopeSelector: string} {
-    return {
-      scopeSelector: ''
-    };
-  },
+  static defaultProps: {scopeSelector: string} = {
+    scopeSelector: ''
+  };
 
   _buildStyles(styles: Object): string {
     const userAgent = (
@@ -60,7 +58,7 @@ const Style = React.createClass({
 
       return accumulator;
     }, '');
-  },
+  }
 
   _buildMediaQueryString(
     stylesByMediaQuery: {[mediaQuery: string]: Object}
@@ -74,7 +72,7 @@ const Style = React.createClass({
     });
 
     return mediaQueryString;
-  },
+  }
 
   render(): ?ReactElement {
     if (!this.props.rules) {
@@ -87,6 +85,6 @@ const Style = React.createClass({
       <style dangerouslySetInnerHTML={{__html: styles}} />
     );
   }
-});
+}
 
 export default Style;


### PR DESCRIPTION
This PR updates Radium's components to use [PureComponent](https://facebook.github.io/react/docs/react-api.html#react.purecomponent), which performs a shallow equality check to avoid unecessary rendering.
Addresses #708