### PR TITLE
Update inline-style-prefixer to version 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.3.13",
     "exenv": "^1.2.0",
-    "inline-style-prefixer": "^2.0.1",
+    "inline-style-prefixer": "^2.0.4",
     "rimraf": "^2.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.3.13",
     "exenv": "^1.2.0",
-    "inline-style-prefixer": "^2.0.4",
+    "inline-style-prefixer": "^2.0.5",
     "rimraf": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes some vender prefixing issues, including a significant one affecting iOS 8 Chrome 47:
https://github.com/rofrischmann/inline-style-prefixer/issues/72