### PR TITLE
fix `getDOMNode` throwing errors with replacement `ReactDOM.findDOMNode` of Examples

### DIFF
--- a/examples/components/computed-well.jsx
+++ b/examples/components/computed-well.jsx
@@ -12,6 +12,7 @@
  */
 
 const React = require('react');
+const ReactDOM = require('react-dom');
 const Radium = require('../../src/index');
 
 const ComputedWell = React.createClass({
@@ -33,7 +34,7 @@ const ComputedWell = React.createClass({
     ev.preventDefault();
 
     this.setState({
-      dynamicBg: this.refs.input.getDOMNode().value,
+      dynamicBg: ReactDOM.findDOMNode(this.refs.input).value,
     });
   },
 


### PR DESCRIPTION
Minor patch to the Examples application.

Original Behaviour: Clicking on the "Change Background color" button would result in an `Uncaught TypeError: this.refs.input.getDOMNode is not a function` error on line `/examples/components/computed-well.jsx:36`.

Update: Replacing use of `this.refs.input.getDOMNode().value` with `ReactDOM.findDOMNode(this.refs.input).value` fixes the issue.