### PR TITLE
List react ^15.3.0 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "inline-style-prefixer": "^2.0.5",
     "rimraf": "^2.6.1"
   },
+  "peerDependencies": {
+    "react": "^15.3.0"
+  },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.4.0",


### PR DESCRIPTION
Resolves: https://github.com/FormidableLabs/radium/issues/885

## Context
Now that classes extend from React.PureComponent after this PR: https://github.com/FormidableLabs/radium/pull/868

Classes exported from radium have a minimum dependency on React 15.3.x, when they introduced the feature.

Exact patch note for React.PureComponent: https://github.com/facebook/react/blob/master/CHANGELOG.md#1530-july-29-2016

## This PR:
- Lists `react ^15.3.0` in `peerDependencies`.
  - This will let consumers of this library know which react version to expect to use/support
