### PR TITLE
Import PropTypes from a separate module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radium",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "A set of tools to manage inline styles on React elements",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -36,16 +36,9 @@
   "license": "MIT",
   "dependencies": {
     "array-find": "^1.0.0",
-    "babel-cli": "^6.24.0",
-    "babel-core": "^6.24.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-1": "^6.22.0",
     "exenv": "^1.2.1",
     "inline-style-prefixer": "^2.0.5",
+    "prop-types": "^15.5.8",
     "rimraf": "^2.6.1"
   },
   "peerDependencies": {
@@ -91,6 +84,14 @@
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.4.2"
+    "webpack-dev-server": "^2.4.2",
+    "babel-cli": "^6.24.0",
+    "babel-core": "^6.24.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-react": "^6.23.0",
+    "babel-preset-stage-1": "^6.22.0"
   }
 }

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -2,7 +2,9 @@
 
 import Radium from 'index.js';
 import MouseUpListener from 'plugins/mouse-up-listener.js';
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import {getRenderOutput, getElement} from 'test-helpers';

--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, {PureComponent, PropTypes} from 'react';
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
 
 import Enhancer from '../enhancer';
 import StyleKeeper from '../style-keeper';

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -2,7 +2,8 @@
 
 import cssRuleSetToString from '../css-rule-set-to-string';
 
-import React, {PropTypes, PureComponent} from 'react';
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
 
 class Style extends PureComponent {
   static propTypes = {

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import {Component, PropTypes} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
 
 import StyleKeeper from './style-keeper.js';
 import resolveStyles from './resolve-styles.js';


### PR DESCRIPTION
In React 15, importing PropTypes from the React library is obsolete and should be replaced with a separate `prop-types` module.