### PR TITLE
Move prop-types to `dependencies` instead of  `peerDependencies`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ notifications:
 cache: yarn
 
 script:
-  - npm run lint
-  - npm run test-coverage
+  - yarn run lint
+  - yarn run test-coverage
   # Upload to coveralls, but don't _fail_ if coveralls is down.
   - cat coverage/lcov.info | node_modules/.bin/coveralls || echo "Coveralls upload failed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,23 @@
 # Radium Changelog
 
+## UNRELEASED
+
+### Bug Fixes
+- Makes `prop-types` a `dependencies` instead of a `peerDependencies` in `package.json` per the `prop-types` [integration guide](https://github.com/facebook/prop-types#how-to-depend-on-this-package).
+
 ## 0.19.0 (May 15, 2017)
-- Unreverts PropTypes-related diff, which is now a minor version instead of a
-    patch
+
+### Improvements
+- Unreverts PropTypes-related diff, which is now a minor version instead of a patch
 
 ## 0.18.4 (May 15, 2017)
-- Reverts PropTypes-related diff, which should have been a minor version instead
-    of a patch
+
+### Bug Fixes
+- Reverts PropTypes-related diff, which should have been a minor version instead of a patch
 
 ## 0.18.3 (May 15, 2017)
+
+### Improvements
 - Update dependencies
 - Update deprecated React syntax in examples
 - Use React "prop-types" package

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel": "rimraf lib && babel src/ -d lib/",
     "dist": "webpack && webpack --config=webpack.config.minified.js",
     "examples": "webpack-dev-server --config examples/webpack.config.js --no-info --content-base examples/",
-    "deps-fix": "babel-node ./npm-scripts/move-babel-to-dependencies.js",
+    "deps-fix": "babel-node npm-scripts/move-babel-to-dependencies.js",
     "deps-restore": "git checkout package.json",
     "flow": "flow check",
     "lib": "npm run babel && rimraf lib/__tests__ lib/__mocks__",
@@ -26,7 +26,7 @@
     "postinstall": "cd lib || npm run lib",
     "prepublish": "npm run lib && npm run dist && not-in-publish || (npm test && npm run lint && npm run deps-fix)",
     "postpublish": "npm run deps-restore",
-    "start": "./node_modules/.bin/babel-node examples/server.js",
+    "start": "node_modules/.bin/babel-node examples/server.js",
     "test": "karma start",
     "test-coverage": "karma start karma.conf.coverage.js",
     "test-ie": "karma start karma.conf.ie.js",
@@ -46,10 +46,10 @@
     "babel-preset-stage-1": "^6.22.0",
     "exenv": "^1.2.1",
     "inline-style-prefixer": "^2.0.5",
+    "prop-types": "^15.5.8",
     "rimraf": "^2.6.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.8",
     "react": "^15.3.0"
   },
   "devDependencies": {
@@ -86,7 +86,6 @@
     "object-assign": "^4.1.1",
     "phantomjs-prebuilt": "^2.1.14",
     "prettier": "^0.22.0",
-    "prop-types": "^15.5.8",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",


### PR DESCRIPTION
- Move prop-types to `dependencies` instead of  `peerDependencies`
- Improve travis to use `yarn` for task running since it already installs using that
- Update changelog.

/cc @alexlande @mhink @MichaelDeBoey