### PR TITLE
fixBug: React.createClass is not a function

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -14,7 +14,7 @@
 /* eslint-disable no-use-before-define */
 
 const React = require('react');
-
+const createReactClass = require('create-react-class');
 const CommonStyles = require('./common.styles');
 const Button = require('./components/button.jsx');
 const ComputedWell = require('./components/computed-well.jsx');
@@ -63,7 +63,7 @@ HoverMessage = Radium(HoverMessage);
   }
 }
 
-let Spinner = React.createClass({
+let Spinner = createReactClass({
   render() {
     return (
       <div>
@@ -85,7 +85,7 @@ const VisitedLink = Radium(() => (
   </a>
 ));
 
-let App = React.createClass({
+let App = createReactClass({
   _remount: function() {
     this.setState({shouldRenderNull: true});
 

--- a/examples/components/computed-well.jsx
+++ b/examples/components/computed-well.jsx
@@ -14,8 +14,8 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const Radium = require('../../src/index');
-
-const ComputedWell = React.createClass({
+const createReactClass = require('create-react-class');
+const ComputedWell = createReactClass({
   getInitialState: function() {
     return {
       dynamicBg: '#000',

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "concurrently": "^3.4.0",
     "core-js": "^2.5.1",
     "coveralls": "^2.12.0",
+    "create-react-class": "^15.6.2",
     "eslint": "^3.17.1",
     "eslint-plugin-flow-vars": "^0.5.0",
     "eslint-plugin-prettier": "^2.0.1",


### PR DESCRIPTION
 After React version 15.5 we can't use React.createClass, [https://reactjs.org/blog/2017/04/07/react-v15.5.0.html](url), create-react-class fix it. 