### PR TITLE
Remove trailing commas + rules.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -274,7 +274,6 @@ rules:
       "error",
       {
         "bracketSpacing": false,
-        "trailingComma": "all",
         "singleQuote": true
       }
     ]

--- a/examples/app.js
+++ b/examples/app.js
@@ -94,7 +94,7 @@ class App extends React.Component {
       function() {
         this.setState({shouldRenderNull: false});
       }.bind(this),
-      100,
+      100
     );
   }
 
@@ -124,7 +124,7 @@ class App extends React.Component {
         <Button
           style={{
             fontSize: '1.5em',
-            borderRadius: 3,
+            borderRadius: 3
           }}
         >
           Button
@@ -147,23 +147,23 @@ class App extends React.Component {
           rules={{
             body: {
               margin: 0,
-              fontFamily: 'Helvetica Neue, Helvetica, Arial, sans-serif',
+              fontFamily: 'Helvetica Neue, Helvetica, Arial, sans-serif'
             },
             mediaQueries: {
               '(max-width: 600px)': {
                 body: {
-                  background: 'gray',
-                },
+                  background: 'gray'
+                }
               },
               '(max-width: 500px)': {
                 body: {
-                  background: 'blue',
+                  background: 'blue'
                 },
                 'p, h1': {
-                  color: 'white',
-                },
-              },
-            },
+                  color: 'white'
+                }
+              }
+            }
           }}
         />
 
@@ -173,9 +173,9 @@ class App extends React.Component {
           <Style
             rules={{
               span: {
-                fontFamily: 'Lucida Console, Monaco, monospace',
+                fontFamily: 'Lucida Console, Monaco, monospace'
               },
-              color: 'blue',
+              color: 'blue'
             }}
             scopeSelector=".scoping-class"
           />
@@ -194,26 +194,26 @@ const squareStyles = {
     border: 'solid 1px white',
     float: 'left',
     height: 100,
-    width: 100,
+    width: 100
   },
   one: {
     ':hover': {
-      background: 'blue',
-    },
+      background: 'blue'
+    }
   },
   two: {
     ':hover': {
-      background: 'red',
-    },
+      background: 'red'
+    }
   },
   three: {
     ':hover': {
-      background: 'yellow',
+      background: 'yellow'
     },
     ':disabled': {
-      background: 'red',
-    },
-  },
+      background: 'red'
+    }
+  }
 };
 
 const tileStyle = {
@@ -227,17 +227,17 @@ const tileStyle = {
   cursor: 'pointer',
 
   ':hover': {
-    background: '#999',
-  },
+    background: '#999'
+  }
 };
 
 const pulseAnimation = Radium.keyframes(
   {
     '0%': {width: '10%'},
     '50%': {width: '50%'},
-    '100%': {width: '10%'},
+    '100%': {width: '10%'}
   },
-  'pulse',
+  'pulse'
 );
 
 const spinnerStyles = {
@@ -246,14 +246,14 @@ const spinnerStyles = {
     animationName: pulseAnimation,
     background: 'blue',
     height: '4px',
-    margin: '0 auto',
-  },
+    margin: '0 auto'
+  }
 };
 
 const listStyle = {
   ...resetListStyle,
   ...resetBoxModel,
-  margin: 15,
+  margin: 15
 };
 
 module.exports = App;

--- a/examples/common.styles.js
+++ b/examples/common.styles.js
@@ -1,6 +1,6 @@
 module.exports = {
   resetListStyle: {
-    listStyle: 'none',
+    listStyle: 'none'
   },
   resetBoxModel: {
     marginTop: 0,
@@ -10,6 +10,6 @@ module.exports = {
     paddingTop: 0,
     paddingRight: 0,
     paddingBottom: 0,
-    paddingLeft: 0,
-  },
+    paddingLeft: 0
+  }
 };

--- a/examples/components/button.js
+++ b/examples/components/button.js
@@ -25,7 +25,7 @@ const PropTypes = require('prop-types');
         style={[
           styles.base,
           this.props.color === 'red' && styles.red,
-          this.props.style,
+          this.props.style
         ]}
       >
         {this.props.children}
@@ -36,7 +36,7 @@ const PropTypes = require('prop-types');
 
 Button.propTypes = {
   color: PropTypes.string,
-  onClick: PropTypes.func,
+  onClick: PropTypes.func
 };
 
 const styles = {
@@ -51,40 +51,40 @@ const styles = {
     outline: 'none',
 
     '@media (min-width: 992px)': {
-      padding: '0.6em 1.2em',
+      padding: '0.6em 1.2em'
     },
 
     '@media (min-width: 1200px)': {
-      padding: '0.8em 1.5em',
+      padding: '0.8em 1.5em'
     },
 
     ':hover': {
-      backgroundColor: '#0088FF',
+      backgroundColor: '#0088FF'
     },
 
     ':focus': {
-      backgroundColor: '#0088FF',
+      backgroundColor: '#0088FF'
     },
 
     ':active': {
       backgroundColor: '#005299',
-      transform: 'translateY(2px)',
-    },
+      transform: 'translateY(2px)'
+    }
   },
 
   red: {
     backgroundColor: '#d90000',
 
     ':hover': {
-      backgroundColor: '#FF0000',
+      backgroundColor: '#FF0000'
     },
     ':focus': {
-      backgroundColor: '#FF0000',
+      backgroundColor: '#FF0000'
     },
     ':active': {
-      backgroundColor: '#990000',
-    },
-  },
+      backgroundColor: '#990000'
+    }
+  }
 };
 
 module.exports = Button;

--- a/examples/components/computed-well.js
+++ b/examples/components/computed-well.js
@@ -18,7 +18,7 @@ const Radium = require('../../src/index');
 class ComputedWell extends React.Component {
   getInitialState() {
     return {
-      dynamicBg: '#000',
+      dynamicBg: '#000'
     };
   }
 
@@ -26,7 +26,7 @@ class ComputedWell extends React.Component {
     return {
       padding: '1em',
       borderRadius: 5,
-      background: this.state.dynamicBg,
+      background: this.state.dynamicBg
     };
   }
 
@@ -34,7 +34,7 @@ class ComputedWell extends React.Component {
     ev.preventDefault();
 
     this.setState({
-      dynamicBg: ReactDOM.findDOMNode(this.refs.input).value,
+      dynamicBg: ReactDOM.findDOMNode(this.refs.input).value
     });
   }
 

--- a/examples/server.js
+++ b/examples/server.js
@@ -30,7 +30,7 @@ app.use('/app.js', proxy('localhost:8080', {forwardPath: () => '/app.js'}));
 
 app.get('/', (req, res) => {
   const appHtml = ReactDOMServer.renderToString(
-    <App radiumConfig={{userAgent: req.headers['user-agent']}} />,
+    <App radiumConfig={{userAgent: req.headers['user-agent']}} />
   );
   res.write(indexHTML.replace('<!-- {{app}} -->', appHtml));
   res.end();

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -16,20 +16,20 @@ var path = require('path'); // eslint-disable-line no-var
 module.exports = {
   cache: true,
   entry: {
-    app: './examples/client.js',
+    app: './examples/client.js'
   },
   output: {
     path: path.join(__dirname, '/dist'),
     publicPath: '/',
     filename: '[name].js',
-    chunkFilename: '[chunkhash].js',
+    chunkFilename: '[chunkhash].js'
   },
   module: {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel-loader',
-      },
-    ],
-  },
+        loader: 'babel-loader'
+      }
+    ]
+  }
 };

--- a/karma.conf.coverage.js
+++ b/karma.conf.coverage.js
@@ -4,13 +4,13 @@ module.exports = function(config) {
     coverageReporter: {
       reporters: [
         {
-          type: 'text',
+          type: 'text'
         },
         {
           type: 'lcovonly',
-          subdir: '.',
-        },
-      ],
-    },
+          subdir: '.'
+        }
+      ]
+    }
   });
 };

--- a/karma.conf.ie.js
+++ b/karma.conf.ie.js
@@ -6,8 +6,8 @@ module.exports = function(config) {
     customLaunchers: {
       IE9: {
         base: 'IE',
-        'x-ua-compatible': 'IE=EmulateIE9',
-      },
-    },
+        'x-ua-compatible': 'IE=EmulateIE9'
+      }
+    }
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,14 +8,14 @@ module.exports = function(config) {
       // Polyfills for PhantomJS in React 16.
       require.resolve('core-js/es6/map'),
       require.resolve('core-js/es6/set'),
-      'src/__tests__/**/*.js',
+      'src/__tests__/**/*.js'
     ],
     preprocessors: {
       [path.join(
         path.dirname(require.resolve('core-js/package.json')),
         'es6/**/*.js' // eslint-disable-line prettier/prettier
       )]: ['webpack'],
-      'src/__tests__/**/*.js': ['webpack'],
+      'src/__tests__/**/*.js': ['webpack']
     },
     webpack: {
       cache: true,
@@ -25,33 +25,33 @@ module.exports = function(config) {
             test: /\.js$/,
             enforce: 'pre',
             include: path.resolve('src/__tests__/'),
-            loader: 'babel-loader',
+            loader: 'babel-loader'
           },
           {
             test: /\.js$/,
             include: path.resolve('src/'),
             enforce: 'pre',
             exclude: /(__tests__|__mocks__)/,
-            loader: 'isparta-loader?babel-loader',
+            loader: 'isparta-loader?babel-loader'
           },
           {
             test: /\.js$/,
             exclude: [/node_modules/],
-            loader: 'babel-loader',
+            loader: 'babel-loader'
           },
           {
             test: /\.css$/,
-            loader: 'style-loader!css-loader',
-          },
-        ],
+            loader: 'style-loader!css-loader'
+          }
+        ]
       },
       resolve: {
         modules: [
           path.join(__dirname, 'node_modules'),
-          path.join(__dirname, 'src'),
+          path.join(__dirname, 'src')
         ],
-        extensions: ['.js', '.jsx'],
-      },
+        extensions: ['.js', '.jsx']
+      }
     },
     webpackServer: {
       quiet: false,
@@ -63,8 +63,8 @@ module.exports = function(config) {
         hash: false,
         timings: false,
         chunks: false,
-        chunkModules: false,
-      },
+        chunkModules: false
+      }
     },
     exclude: [],
     port: 8080,
@@ -81,10 +81,10 @@ module.exports = function(config) {
       'karma-phantomjs-launcher',
       'karma-phantomjs-shim',
       'karma-sinon-chai',
-      'karma-webpack',
+      'karma-webpack'
     ],
     coverageReporter: {
-      type: 'text',
+      type: 'text'
     },
     browserConsoleLogOptions: {
       level: 'log',
@@ -92,6 +92,6 @@ module.exports = function(config) {
       terminal: true
     },
     captureTimeout: 100000,
-    singleRun: true,
+    singleRun: true
   });
 };

--- a/src/__mocks__/exenv.js
+++ b/src/__mocks__/exenv.js
@@ -1,4 +1,4 @@
 export default {
   canUseDOM: true,
-  canUseEventListeners: true,
+  canUseEventListeners: true
 };

--- a/src/__mocks__/prefixer.js
+++ b/src/__mocks__/prefixer.js
@@ -1,3 +1,3 @@
 export default {
-  getPrefixedStyle: style => style,
+  getPrefixedStyle: style => style
 };

--- a/src/__tests__/camel-case-props-to-dash-case-test.js
+++ b/src/__tests__/camel-case-props-to-dash-case-test.js
@@ -5,13 +5,13 @@ describe('camelCasePropsToDashCase', function() {
     const result = camelCasePropsToDashCase({
       borderLeft: '1px solid black',
       WebkitBoxSizing: 'border-box',
-      msTransform: 'rotate(90deg)',
+      msTransform: 'rotate(90deg)'
     });
 
     expect(result).to.deep.equal({
       'border-left': '1px solid black',
       '-webkit-box-sizing': 'border-box',
-      '-ms-transform': 'rotate(90deg)',
+      '-ms-transform': 'rotate(90deg)'
     });
   });
 });

--- a/src/__tests__/enhancer-test.js
+++ b/src/__tests__/enhancer-test.js
@@ -1,6 +1,6 @@
 const resolveStyles = sinon.spy(require('resolve-styles.js'));
 const Enhancer = require('inject-loader!enhancer.js')({
-  './resolve-styles.js': resolveStyles,
+  './resolve-styles.js': resolveStyles
 });
 
 import React, {Component} from 'react';
@@ -123,7 +123,7 @@ describe('Enhancer', () => {
     const mediaQueryListenersByQuery = {
       '(min-width: 1000px)': {remove: sinon.spy()},
       '(max-width: 600px)': {remove: sinon.spy()},
-      '(min-resolution: 2dppx)': {remove: sinon.spy()},
+      '(min-resolution: 2dppx)': {remove: sinon.spy()}
     };
     class Composed extends Component {
       constructor() {

--- a/src/__tests__/get-state-test.js
+++ b/src/__tests__/get-state-test.js
@@ -5,7 +5,7 @@ describe('getState', function() {
     const result = getState(
       {_radiumStyleState: {'0': {':hover': true}}},
       0,
-      ':hover',
+      ':hover'
     );
     expect(result).to.equal(true);
   });

--- a/src/__tests__/keyframes-test.js
+++ b/src/__tests__/keyframes-test.js
@@ -32,7 +32,7 @@ describe('keyframes', () => {
         from {left: 0;}
         to {left: 100px;}
       }
-    `,
+    `
     );
   });
 
@@ -40,9 +40,9 @@ describe('keyframes', () => {
     const animation = keyframes(
       {
         from: {left: '-1000px'},
-        to: {left: 0},
+        to: {left: 0}
       },
-      'SlideFromLeft',
+      'SlideFromLeft'
     );
 
     class TestComponent extends Component {
@@ -66,7 +66,7 @@ describe('keyframes', () => {
           left: 0;
         }
       }
-    `,
+    `
     );
   });
 
@@ -74,9 +74,9 @@ describe('keyframes', () => {
     const animation = keyframes(
       {
         from: {left: -1000},
-        to: {left: 10},
+        to: {left: 10}
       },
-      'SlideFromLeft',
+      'SlideFromLeft'
     );
 
     class TestComponent extends Component {
@@ -100,7 +100,7 @@ describe('keyframes', () => {
           left: 10px;
         }
       }
-    `,
+    `
     );
   });
 
@@ -108,9 +108,9 @@ describe('keyframes', () => {
     const animation = keyframes(
       {
         from: {left: '-1000px'},
-        to: {left: 0},
+        to: {left: 0}
       },
-      'SlideFromLeft',
+      'SlideFromLeft'
     );
 
     @Radium class ChildComponent extends Component {
@@ -144,7 +144,7 @@ describe('keyframes', () => {
           left: 0;
         }
       }
-    `,
+    `
     );
   });
 });

--- a/src/__tests__/media-query-test.js
+++ b/src/__tests__/media-query-test.js
@@ -9,7 +9,7 @@ import {
   expectColor,
   expectCSS,
   getRenderOutput,
-  getElement,
+  getElement
 } from 'test-helpers';
 
 // Win on at least ie9 _can't_ sinon.stub() window.onerror like normal.
@@ -46,7 +46,7 @@ describe('Media query tests', () => {
         return (
           <div
             style={{
-              '@media (min-width: 600px)': {':hover': {color: 'blue'}},
+              '@media (min-width: 600px)': {':hover': {color: 'blue'}}
             }}
           />
         );
@@ -69,7 +69,7 @@ describe('Media query tests', () => {
         return (
           <div
             style={{
-              '@media (min-width: 600px)': {':hover': {color: 'blue'}},
+              '@media (min-width: 600px)': {':hover': {color: 'blue'}}
             }}
           />
         );
@@ -96,13 +96,13 @@ describe('Media query tests', () => {
             <div
               key="first"
               style={{
-                '@media (max-width: 400px)': {':hover': {color: 'blue'}},
+                '@media (max-width: 400px)': {':hover': {color: 'blue'}}
               }}
             />
             <div
               key="second"
               style={{
-                '@media (max-width: 400px)': {':hover': {color: 'blue'}},
+                '@media (max-width: 400px)': {':hover': {color: 'blue'}}
               }}
             />
           </div>
@@ -121,7 +121,7 @@ describe('Media query tests', () => {
       return {
         matches: true,
         addListener: () => {},
-        removeListener: () => {},
+        removeListener: () => {}
       };
     };
 
@@ -131,7 +131,7 @@ describe('Media query tests', () => {
         return (
           <div
             style={{
-              '@media (min-width: 600px)': {':hover': {color: 'blue'}},
+              '@media (min-width: 600px)': {':hover': {color: 'blue'}}
             }}
           />
         );
@@ -150,7 +150,7 @@ describe('Media query tests', () => {
       return {
         matches: true,
         addListener: () => {},
-        removeListener: () => {},
+        removeListener: () => {}
       };
     };
 
@@ -163,10 +163,10 @@ describe('Media query tests', () => {
               {':hover': {background: 'green', color: 'green'}},
               {
                 '@media (max-width: 400px)': {
-                  ':hover': {background: 'yellow'},
-                },
+                  ':hover': {background: 'yellow'}
+                }
               },
-              {'@media (max-width: 400px)': {':hover': {color: 'white'}}},
+              {'@media (max-width: 400px)': {':hover': {color: 'white'}}}
             ]}
           />
         );
@@ -193,7 +193,7 @@ describe('Media query tests', () => {
         return (
           <div
             style={{
-              '@media (min-width: 600px)': {':hover': {color: 'blue'}},
+              '@media (min-width: 600px)': {':hover': {color: 'blue'}}
             }}
           />
         );
@@ -224,7 +224,7 @@ describe('Media query tests', () => {
         return (
           <div
             style={{
-              '@media (min-width: 600px)': {':hover': {color: 'blue'}},
+              '@media (min-width: 600px)': {':hover': {color: 'blue'}}
             }}
           />
         );
@@ -241,7 +241,7 @@ describe('Media query tests', () => {
   it('renders top level print styles as CSS', () => {
     const matchMedia = sinon.spy(() => ({
       addListener: () => {},
-      matches: true,
+      matches: true
     }));
 
     const ChildComponent = Radium(() => (
@@ -268,14 +268,14 @@ describe('Media query tests', () => {
           color:black !important;
         }
       }
-    `,
+    `
     );
   });
 
   it("doesn't error on unmount", () => {
     const matchMedia = () => ({
       addListener: () => {},
-      matches: true,
+      matches: true
     });
 
     const ChildComponent = Radium(() => (
@@ -299,11 +299,11 @@ describe('Media query tests', () => {
         style={[
           {
             '@media (min-width: 10px)': {background: 'green'},
-            '@media (min-width: 20px)': {color: 'blue'},
+            '@media (min-width: 20px)': {color: 'blue'}
           },
           {
-            '@media (min-width: 10px)': {color: 'white'},
-          },
+            '@media (min-width: 10px)': {color: 'white'}
+          }
         ]}
       />
     ));
@@ -421,7 +421,7 @@ describe('Media query tests', () => {
       return {
         matches: true,
         addListener: addListener,
-        removeListener() {},
+        removeListener() {}
       };
     };
 
@@ -431,7 +431,7 @@ describe('Media query tests', () => {
         return (
           <div
             style={{
-              '@media (min-width: 600px)': {':hover': {color: 'blue'}},
+              '@media (min-width: 600px)': {':hover': {color: 'blue'}}
             }}
           />
         );

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -30,7 +30,7 @@ describe('Radium blackbox tests', () => {
 
     expect(output.props.style).to.deep.equal({
       color: 'blue',
-      background: 'red',
+      background: 'red'
     });
   });
 
@@ -41,7 +41,7 @@ describe('Radium blackbox tests', () => {
           <div
             style={[
               [{color: 'blue'}, [{height: '2px', padding: '9px'}]],
-              {background: 'red'},
+              {background: 'red'}
             ]}
           />
         );
@@ -54,7 +54,7 @@ describe('Radium blackbox tests', () => {
       color: 'blue',
       background: 'red',
       height: '2px',
-      padding: '9px',
+      padding: '9px'
     });
   });
 
@@ -75,7 +75,7 @@ describe('Radium blackbox tests', () => {
 
     expect(output.props.header.props.style).to.deep.equal({
       color: 'blue',
-      background: 'red',
+      background: 'red'
     });
   });
 
@@ -94,7 +94,7 @@ describe('Radium blackbox tests', () => {
               <div
                 style={[
                   {color: 'blue'},
-                  {background: 'red', ':active': {color: 'green'}},
+                  {background: 'red', ':active': {color: 'green'}}
                 ]}
               />
             }
@@ -130,7 +130,7 @@ describe('Radium blackbox tests', () => {
               <div
                 style={[
                   {color: 'blue'},
-                  {background: 'red', ':active': {color: 'green'}},
+                  {background: 'red', ':active': {color: 'green'}}
                 ]}
               >
                 {arg}
@@ -162,7 +162,7 @@ describe('Radium blackbox tests', () => {
             style={{
               background: 'red',
               color: 'blue',
-              ':hover': {color: 'green'},
+              ':hover': {color: 'green'}
             }}
           />
         );
@@ -189,7 +189,7 @@ describe('Radium blackbox tests', () => {
             style={{
               background: 'red',
               color: 'blue',
-              ':active': {color: 'green'},
+              ':active': {color: 'green'}
             }}
           />
         );
@@ -218,7 +218,7 @@ describe('Radium blackbox tests', () => {
               style={{
                 background: 'red',
                 color: 'blue',
-                ':active': {color: 'green'},
+                ':active': {color: 'green'}
               }}
             />
             <button
@@ -226,7 +226,7 @@ describe('Radium blackbox tests', () => {
               style={{
                 background: 'red',
                 color: 'blue',
-                ':active': {color: 'green'},
+                ':active': {color: 'green'}
               }}
             />
             <nav
@@ -234,7 +234,7 @@ describe('Radium blackbox tests', () => {
               style={{
                 background: 'red',
                 color: 'blue',
-                ':active': {color: 'green'},
+                ':active': {color: 'green'}
               }}
             />
           </div>
@@ -279,14 +279,14 @@ describe('Radium blackbox tests', () => {
                   key="header"
                   style={{
                     color: 'yellow',
-                    ':hover': {color: 'blue'},
+                    ':hover': {color: 'blue'}
                   }}
                 />
                 <footer
                   key="footer"
                   style={{
                     color: 'green',
-                    ':hover': {color: 'red'},
+                    ':hover': {color: 'red'}
                   }}
                 />
               </section>
@@ -347,7 +347,7 @@ describe('Radium blackbox tests', () => {
         return (
           <div
             style={{
-              background: {toString: () => 'red'},
+              background: {toString: () => 'red'}
             }}
           />
         );
@@ -365,19 +365,19 @@ describe('Radium blackbox tests', () => {
       return {
         matches: true,
         addListener: function() {},
-        removeListener: function() {},
+        removeListener: function() {}
       };
     };
 
     @Radium({
-      matchMedia: truthyMatchMedia,
+      matchMedia: truthyMatchMedia
     })
     class TestComponent extends Component {
       render() {
         return (
           <div
             style={{
-              '@media (min-width: 600px)': {':hover': {color: 'blue'}},
+              '@media (min-width: 600px)': {':hover': {color: 'blue'}}
             }}
           />
         );
@@ -398,7 +398,7 @@ describe('Radium blackbox tests', () => {
         return (
           <div
             style={{
-              height: ['100%', '100vh'],
+              height: ['100%', '100vh']
             }}
           />
         );
@@ -418,7 +418,7 @@ describe('Radium blackbox tests', () => {
             style={{
               background: 'red',
               color: 'blue',
-              ':active': {color: 'green'},
+              ':active': {color: 'green'}
             }}
           />
         );
@@ -457,9 +457,9 @@ describe('Radium blackbox tests', () => {
       <TestComponent>
         {{
           nav: <nav>nav</nav>,
-          main: <main>main</main>,
+          main: <main>main</main>
         }}
-      </TestComponent>,
+      </TestComponent>
     );
 
     const nav = getElement(output, 'nav');
@@ -484,7 +484,7 @@ describe('Radium blackbox tests', () => {
     const output = TestUtils.renderIntoDocument(
       <TestComponent>
         {[<nav key="nav">nav</nav>, <main key="main">main</main>]}
-      </TestComponent>,
+      </TestComponent>
     );
 
     const nav = getElement(output, 'nav');
@@ -626,7 +626,7 @@ describe('Radium blackbox tests', () => {
       }
 
       const output = TestUtils.renderIntoDocument(
-        <TestComponent radiumConfig={{plugins: [makeItRedPlugin]}} />,
+        <TestComponent radiumConfig={{plugins: [makeItRedPlugin]}} />
       );
       const div = getElement(output, 'div');
 
@@ -676,7 +676,7 @@ describe('Radium blackbox tests', () => {
     MyStatelessComponent = Radium(MyStatelessComponent);
 
     const output = TestUtils.renderIntoDocument(
-      <MyStatelessComponent>hello world</MyStatelessComponent>,
+      <MyStatelessComponent>hello world</MyStatelessComponent>
     );
     const div = getElement(output, 'div');
 
@@ -707,14 +707,14 @@ describe('Radium blackbox tests', () => {
       </div>
     );
     MyStatelessComponent.contextTypes = {
-      hoverColor: PropTypes.string,
+      hoverColor: PropTypes.string
     };
     MyStatelessComponent = Radium(MyStatelessComponent);
 
     class ContextGivingWrapper extends Component {
       getChildContext() {
         return {
-          hoverColor: 'green',
+          hoverColor: 'green'
         };
       }
       render() {
@@ -722,13 +722,13 @@ describe('Radium blackbox tests', () => {
       }
     }
     ContextGivingWrapper.childContextTypes = {
-      hoverColor: PropTypes.string,
+      hoverColor: PropTypes.string
     };
 
     const output = TestUtils.renderIntoDocument(
       <ContextGivingWrapper>
         <MyStatelessComponent>hello world</MyStatelessComponent>
-      </ContextGivingWrapper>,
+      </ContextGivingWrapper>
     );
     const div = getElement(output, 'div');
 
@@ -781,7 +781,7 @@ describe('Radium blackbox tests', () => {
       }
 
       TestUtils.renderIntoDocument(
-        <TestComponent radiumConfig={{plugins: [plugin]}} />,
+        <TestComponent radiumConfig={{plugins: [plugin]}} />
       );
 
       expect(plugin).to.have.been.called;
@@ -803,7 +803,7 @@ describe('Radium blackbox tests', () => {
       }
 
       TestUtils.renderIntoDocument(
-        <ParentComponent radiumConfig={{plugins: [plugin]}} />,
+        <ParentComponent radiumConfig={{plugins: [plugin]}} />
       );
 
       expect(plugin).to.have.callCount(2);

--- a/src/__tests__/resolve-styles-test.js
+++ b/src/__tests__/resolve-styles-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import MouseUpListener from 'plugins/mouse-up-listener.js';
 import objectAssign from 'object-assign';
 const resolveStyles = require('inject-loader!resolve-styles.js')({
-  exenv: require('__mocks__/exenv.js'),
+  exenv: require('__mocks__/exenv.js')
 });
 
 const genComponent = function() {
@@ -11,7 +11,7 @@ const genComponent = function() {
       objectAssign(this.state, newState);
     }),
     state: {},
-    _radiumIsMounted: true,
+    _radiumIsMounted: true
   };
 };
 
@@ -108,8 +108,8 @@ describe('resolveStyles', function() {
       // JSX won't let this through, so do it with a plain object instead
       const renderedElement = {
         props: {
-          children: [null],
-        },
+          children: [null]
+        }
       };
 
       const result = resolveStyles(component, renderedElement);
@@ -131,7 +131,7 @@ describe('resolveStyles', function() {
 
       expect(result.props.style).to.deep.equal({
         background: 'white',
-        color: 'blue',
+        color: 'blue'
       });
 
       expect(React.cloneElement).to.have.been.calledOnce;
@@ -151,7 +151,7 @@ describe('resolveStyles', function() {
 
       expect(result.props.style).to.deep.equal({
         background: 'white',
-        color: 'blue',
+        color: 'blue'
       });
     });
 
@@ -166,7 +166,7 @@ describe('resolveStyles', function() {
             ''.someUndefinedVar,
             '',
             [1, 2, 3],
-            {color: 'blue'},
+            {color: 'blue'}
           ]}
         />
       );
@@ -175,7 +175,7 @@ describe('resolveStyles', function() {
 
       expect(result.props.style).to.deep.equal({
         background: 'white',
-        color: 'blue',
+        color: 'blue'
       });
     });
 
@@ -188,7 +188,7 @@ describe('resolveStyles', function() {
       const result = resolveStyles(component, renderedElement);
 
       expect(result.props.style).to.deep.equal({
-        background: 'blue',
+        background: 'blue'
       });
     });
 
@@ -198,7 +198,7 @@ describe('resolveStyles', function() {
         <div
           style={[
             {':hover': {background: 'white'}},
-            {':hover': {color: 'blue'}},
+            {':hover': {color: 'blue'}}
           ]}
         />
       );
@@ -209,7 +209,7 @@ describe('resolveStyles', function() {
 
       expect(result.props.style).to.deep.equal({
         background: 'white',
-        color: 'blue',
+        color: 'blue'
       });
     });
   });
@@ -217,7 +217,7 @@ describe('resolveStyles', function() {
   const createPseduoStyleTests = function(
     pseudo,
     onHandlerName,
-    offHandlerName,
+    offHandlerName
   ) {
     it('strips special styles if not applied', function() {
       const component = genComponent();
@@ -420,7 +420,7 @@ describe('resolveStyles', function() {
       const component = genComponent();
       const style = {
         background: 'blue',
-        ':active': {background: 'red'},
+        ':active': {background: 'red'}
       };
       const renderedElement = <div style={style} />;
 
@@ -437,7 +437,7 @@ describe('resolveStyles', function() {
       const component = genComponent();
       const style = {
         background: 'blue',
-        ':active': {background: 'red'},
+        ':active': {background: 'red'}
       };
       const renderedElement = <div style={style} />;
 
@@ -459,7 +459,7 @@ describe('resolveStyles', function() {
       const component = genComponent();
       const style = {
         background: 'blue',
-        ':active': {background: 'red'},
+        ':active': {background: 'red'}
       };
       const renderedElement = <div style={style} />;
 
@@ -479,7 +479,7 @@ describe('resolveStyles', function() {
       const component = genComponent();
       const style = {
         background: 'blue',
-        ':active': {background: 'red'},
+        ':active': {background: 'red'}
       };
       const originalOnMouseDown = sinon.spy();
       const renderedElement = (
@@ -503,12 +503,12 @@ describe('resolveStyles', function() {
       const stylePermutations = permutate([
         {name: ':active', style: {background: 'red'}},
         {name: ':focus', style: {background: 'yellow'}},
-        {name: ':hover', style: {background: 'blue'}},
+        {name: ':hover', style: {background: 'blue'}}
       ]);
       const onHandlerPermutations = permutate([
         'onFocus',
         'onMouseDown',
-        'onMouseEnter',
+        'onMouseEnter'
       ]);
 
       const createMultiPseudoTest = function(pseudoStyles, onHandlers) {
@@ -532,7 +532,7 @@ describe('resolveStyles', function() {
           result = resolveStyles(component, renderedElement);
 
           expect(result.props.style.background).to.equal(
-            pseudoStyles[pseudoStyles.length - 1].style.background,
+            pseudoStyles[pseudoStyles.length - 1].style.background
           );
         });
       };
@@ -594,7 +594,7 @@ describe('resolveStyles', function() {
       const result = resolveStyles(component, renderedElement);
       expect(result.props.style).to.deep.equal({
         background: 'white',
-        color: 'blue',
+        color: 'blue'
       });
 
       const children = getChildrenArray(result.props.children);
@@ -603,7 +603,7 @@ describe('resolveStyles', function() {
       const componentChildren = getChildrenArray(children[0].props.children);
       expect(componentChildren[0].props.style).to.deep.equal({
         background: 'white',
-        color: 'blue',
+        color: 'blue'
       });
     });
   });
@@ -678,7 +678,7 @@ describe('resolveStyles', function() {
         <div
           style={{
             border: '1px solid black',
-            borderWidth: '0 1px 1px 1px',
+            borderWidth: '0 1px 1px 1px'
           }}
         />
       );
@@ -687,7 +687,7 @@ describe('resolveStyles', function() {
 
       expect(console.warn).to.have.been.called;
       expect(
-        console.warn.firstCall.args[0].indexOf('border'),
+        console.warn.firstCall.args[0].indexOf('border')
       ).to.be.greaterThan(0);
     });
 
@@ -698,8 +698,8 @@ describe('resolveStyles', function() {
           style={{
             ':hover': {
               border: '1px solid black',
-              borderWidth: '0 1px 1px 1px',
-            },
+              borderWidth: '0 1px 1px 1px'
+            }
           }}
         />
       );
@@ -708,7 +708,7 @@ describe('resolveStyles', function() {
 
       expect(console.warn).to.have.been.called;
       expect(
-        console.warn.firstCall.args[0].indexOf('border'),
+        console.warn.firstCall.args[0].indexOf('border')
       ).to.be.greaterThan(0);
     });
 
@@ -718,7 +718,7 @@ describe('resolveStyles', function() {
         <div
           style={{
             border: '1px solid black',
-            borderRadius: '5px',
+            borderRadius: '5px'
           }}
         />
       );

--- a/src/__tests__/style-component-test.js
+++ b/src/__tests__/style-component-test.js
@@ -9,7 +9,7 @@ const MSIE9_USER_AGENT = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Tri
 describe('<Style> component', () => {
   it("adds px suffix to properties that don't accept unitless values", () => {
     const output = TestUtils.renderIntoDocument(
-      <Style rules={{div: {height: 10}}} />,
+      <Style rules={{div: {height: 10}}} />
     );
 
     const style = getElement(output, 'style');
@@ -19,13 +19,13 @@ describe('<Style> component', () => {
       div {
         height: 10px;
       }
-    `,
+    `
     );
   });
 
   it("doesn't add px suffix to properties that accept unitless values", () => {
     const output = TestUtils.renderIntoDocument(
-      <Style rules={{div: {zIndex: 10}}} />,
+      <Style rules={{div: {zIndex: 10}}} />
     );
 
     const style = getElement(output, 'style');
@@ -35,7 +35,7 @@ describe('<Style> component', () => {
       div {
         z-index: 10;
       }
-    `,
+    `
     );
   });
 
@@ -44,7 +44,7 @@ describe('<Style> component', () => {
       <Style
         radiumConfig={{userAgent: MSIE9_USER_AGENT}}
         rules={{div: {transform: 'rotate(90)'}}}
-      />,
+      />
     );
 
     const style = getElement(output, 'style');
@@ -54,7 +54,7 @@ describe('<Style> component', () => {
       div {
         -ms-transform: rotate(90);
       }
-    `,
+    `
     );
   });
 
@@ -63,7 +63,7 @@ describe('<Style> component', () => {
       <Style
         radiumConfig={{userAgent: 'all'}}
         rules={{div: {transform: 'rotate(90)'}}}
-      />,
+      />
     );
 
     const style = getElement(output, 'style');
@@ -75,7 +75,7 @@ describe('<Style> component', () => {
         -ms-transform:rotate(90);
         transform:rotate(90);
       }
-    `,
+    `
     );
   });
 
@@ -84,10 +84,10 @@ describe('<Style> component', () => {
       <Style
         rules={{
           div: {color: 'red'},
-          span: {color: 'blue'},
+          span: {color: 'blue'}
         }}
         scopeSelector=".scope"
-      />,
+      />
     );
 
     const style = getElement(output, 'style');
@@ -100,13 +100,13 @@ describe('<Style> component', () => {
       .scope span {
         color: blue;
       }
-    `,
+    `
     );
   });
 
   it('adds scopeSelector to multiple selectors in a single ruleset', () => {
     const output = TestUtils.renderIntoDocument(
-      <Style rules={{'div, span': {color: 'red'}}} scopeSelector=".scope" />,
+      <Style rules={{'div, span': {color: 'red'}}} scopeSelector=".scope" />
     );
 
     const style = getElement(output, 'style');
@@ -116,7 +116,7 @@ describe('<Style> component', () => {
       .scope div, .scope span {
         color: red;
       }
-    `,
+    `
     );
   });
 
@@ -128,11 +128,11 @@ describe('<Style> component', () => {
           backgroundColor: 'white',
           div: {
             color: 'blue',
-            backgroundColor: 'black',
-          },
+            backgroundColor: 'black'
+          }
         }}
         scopeSelector=".scope"
-      />,
+      />
     );
 
     const style = getElement(output, 'style');
@@ -147,7 +147,7 @@ describe('<Style> component', () => {
         color: blue;
         background-color: black;
       }
-    `,
+    `
     );
   });
 });

--- a/src/__tests__/visited-test.js
+++ b/src/__tests__/visited-test.js
@@ -29,7 +29,7 @@ describe('visited plugin tests', () => {
       .${span.className}:visited {
         color: purple !important;
       }
-    `,
+    `
     );
   });
 

--- a/src/append-important-to-each-value.js
+++ b/src/append-important-to-each-value.js
@@ -6,6 +6,6 @@ import mapObject from './map-object';
 export default function appendImportantToEachValue(style: Object): Object {
   return mapObject(
     style,
-    (result, key) => appendPxIfNeeded(key, style[key]) + ' !important',
+    (result, key) => appendPxIfNeeded(key, style[key]) + ' !important'
   );
 }

--- a/src/append-px-if-needed.js
+++ b/src/append-px-if-needed.js
@@ -33,12 +33,12 @@ const isUnitlessNumber = {
   stopOpacity: true,
   strokeDashoffset: true,
   strokeOpacity: true,
-  strokeWidth: true,
+  strokeWidth: true
 };
 
 export default function appendPxIfNeeded(
   propertyName: string,
-  value: any,
+  value: any
 ): string {
   const needsPxSuffix = !isUnitlessNumber[propertyName] &&
     typeof value === 'number' &&

--- a/src/camel-case-props-to-dash-case.js
+++ b/src/camel-case-props-to-dash-case.js
@@ -25,7 +25,7 @@ const camelCasePropsToDashCase = function(prefixedStyle: Object): Object {
       result[dashCaseKey] = prefixedStyle[key];
       return result;
     },
-    {},
+    {}
   );
 };
 

--- a/src/components/style-root.js
+++ b/src/components/style-root.js
@@ -23,7 +23,7 @@ function _getStyleKeeper(instance): StyleKeeper {
 
 type StyleRootProps = {
   radiumConfig: Config,
-  children: Node,
+  children: Node
 };
 
 class StyleRoot extends PureComponent<StyleRootProps> {
@@ -56,11 +56,11 @@ class StyleRoot extends PureComponent<StyleRootProps> {
 
 StyleRoot.contextTypes = {
   _radiumConfig: PropTypes.object,
-  _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper),
+  _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
 };
 
 StyleRoot.childContextTypes = {
-  _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper),
+  _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
 };
 
 StyleRoot = Enhancer(StyleRoot);

--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -8,7 +8,7 @@ import StyleKeeper from '../style-keeper';
 
 export default class StyleSheet extends PureComponent<{}, {css: string}> {
   static contextTypes = {
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper),
+    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
   };
 
   constructor() {
@@ -20,7 +20,7 @@ export default class StyleSheet extends PureComponent<{}, {css: string}> {
   componentDidMount() {
     this._isMounted = true;
     this._subscription = this.context._radiumStyleKeeper.subscribe(
-      this._onChange,
+      this._onChange
     );
     this._onChange();
   }
@@ -44,7 +44,7 @@ export default class StyleSheet extends PureComponent<{}, {css: string}> {
       () => {
         this._isMounted && this.setState(this._getCSSState());
       },
-      0,
+      0
     );
   };
 

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -10,22 +10,22 @@ import type {Config} from '../config';
 type StyleProps = {
   radiumConfig: Config,
   rules: {},
-  scopeSelector: string,
+  scopeSelector: string
 };
 
 class Style extends PureComponent<StyleProps> {
   static propTypes = {
     radiumConfig: PropTypes.object,
     rules: PropTypes.object,
-    scopeSelector: PropTypes.string,
+    scopeSelector: PropTypes.string
   };
 
   static contextTypes = {
-    _radiumConfig: PropTypes.object,
+    _radiumConfig: PropTypes.object
   };
 
   static defaultProps: {scopeSelector: string} = {
-    scopeSelector: '',
+    scopeSelector: ''
   };
 
   _buildStyles(styles: Object): string {
@@ -44,7 +44,7 @@ class Style extends PureComponent<StyleProps> {
 
         return accumulator;
       },
-      {},
+      {}
     );
     const rootStyles = Object.keys(rootRules).length
       ? cssRuleSetToString(scopeSelector || '', rootRules, userAgent)
@@ -68,18 +68,18 @@ class Style extends PureComponent<StyleProps> {
             accumulator += cssRuleSetToString(
               completeSelector,
               rules,
-              userAgent,
+              userAgent
             );
           }
 
           return accumulator;
         },
-        '',
+        ''
       );
   }
 
   _buildMediaQueryString(
-    stylesByMediaQuery: {[mediaQuery: string]: Object},
+    stylesByMediaQuery: {[mediaQuery: string]: Object}
   ): string {
     let mediaQueryString = '';
 

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ type MediaQueryListListener = (mql: MediaQueryList) => void;
 type MediaQueryList = {
   matches: boolean,
   addListener(listener: MediaQueryListListener): void,
-  removeListener(listener: MediaQueryListListener): void,
+  removeListener(listener: MediaQueryListListener): void
 };
 
 export type Plugin = (pluginConfig: PluginConfig) => PluginResult;
@@ -17,5 +17,5 @@ export type MatchMediaType = (mediaQueryString: string) => MediaQueryList;
 export type Config = {
   matchMedia?: MatchMediaType,
   plugins?: Array<Plugin>,
-  userAgent?: string,
+  userAgent?: string
 };

--- a/src/css-rule-set-to-string.js
+++ b/src/css-rule-set-to-string.js
@@ -16,7 +16,7 @@ function createMarkupForStyles(style: Object): string {
 export default function cssRuleSetToString(
   selector: string,
   rules: Object,
-  userAgent: ?string,
+  userAgent: ?string
 ): string {
   if (!rules) {
     return '';

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -13,7 +13,7 @@ const KEYS_TO_IGNORE_WHEN_COPYING_PROPERTIES = [
   'length',
   'name',
   'prototype',
-  'type',
+  'type'
 ];
 
 function copyProperties(source, target) {
@@ -44,7 +44,7 @@ function isNativeClass(component: Function): boolean {
 function inherits(subClass, superClass) {
   if (typeof superClass !== 'function' && superClass !== null) {
     throw new TypeError(
-      `Super expression must either be null or a function, not ${typeof superClass}`,
+      `Super expression must either be null or a function, not ${typeof superClass}`
     );
   }
 
@@ -53,8 +53,8 @@ function inherits(subClass, superClass) {
       value: subClass,
       enumerable: false,
       writable: true,
-      configurable: true,
-    },
+      configurable: true
+    }
   });
 
   if (superClass) {
@@ -68,7 +68,7 @@ function inherits(subClass, superClass) {
 
 export default function enhanceWithRadium(
   configOrComposedComponent: Class<any> | constructor | Function | Object,
-  config?: Object = {},
+  config?: Object = {}
 ): constructor {
   if (typeof configOrComposedComponent !== 'function') {
     const newConfig = {...config, ...configOrComposedComponent};
@@ -123,7 +123,7 @@ export default function enhanceWithRadium(
     state: Object;
 
     _radiumMediaQueryListenersByQuery: {
-      [query: string]: {remove: () => void},
+      [query: string]: {remove: () => void}
     };
     _radiumMouseUpListener: {remove: () => void};
     _radiumIsMounted: boolean;
@@ -152,7 +152,7 @@ export default function enhanceWithRadium(
           function(query) {
             this._radiumMediaQueryListenersByQuery[query].remove();
           },
-          this,
+          this
         );
       }
     }
@@ -184,7 +184,7 @@ export default function enhanceWithRadium(
       if (config && currentConfig !== config) {
         currentConfig = {
           ...config,
-          ...currentConfig,
+          ...currentConfig
         };
       }
 
@@ -208,7 +208,7 @@ export default function enhanceWithRadium(
   if (RadiumEnhancer.propTypes && RadiumEnhancer.propTypes.style) {
     RadiumEnhancer.propTypes = {
       ...RadiumEnhancer.propTypes,
-      style: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+      style: PropTypes.oneOfType([PropTypes.array, PropTypes.object])
     };
   }
 
@@ -219,13 +219,13 @@ export default function enhanceWithRadium(
   RadiumEnhancer.contextTypes = {
     ...RadiumEnhancer.contextTypes,
     _radiumConfig: PropTypes.object,
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper),
+    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
   };
 
   RadiumEnhancer.childContextTypes = {
     ...RadiumEnhancer.childContextTypes,
     _radiumConfig: PropTypes.object,
-    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper),
+    _radiumStyleKeeper: PropTypes.instanceOf(StyleKeeper)
   };
 
   return RadiumEnhancer;

--- a/src/get-state.js
+++ b/src/get-state.js
@@ -5,7 +5,7 @@ import getStateKey from './get-state-key';
 const getState = function(
   state: {_radiumStyleState: {[key: string]: {[value: string]: boolean}}},
   elementKey: string,
-  value: string,
+  value: string
 ): any {
   const key = getStateKey(elementKey);
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ if (process.env.NODE_ENV !== 'production') {
   Radium.TestMode = {
     clearState: __clearStateForTests,
     disable: __setTestMode.bind(null, false),
-    enable: __setTestMode.bind(null, true),
+    enable: __setTestMode.bind(null, true)
   };
 }
 

--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -6,12 +6,12 @@ import {getPrefixedKeyframes} from './prefixer';
 
 export type Keyframes = {
   __radiumKeyframes: boolean,
-  __process(userAgent?: string): {animationName: string, css: string},
+  __process(userAgent?: string): {animationName: string, css: string}
 };
 
 export default function keyframes(
   keyframeRules: {[percentage: string]: {[key: string]: string | number}},
-  name?: string,
+  name?: string
 ): Keyframes {
   return {
     __radiumKeyframes: true,
@@ -32,6 +32,6 @@ export default function keyframes(
         rules +
         '\n}\n';
       return {css, animationName};
-    },
+    }
   };
 }

--- a/src/map-object.js
+++ b/src/map-object.js
@@ -2,13 +2,13 @@
 
 export default function mapObject<TValue, TNext>(
   object: {[key: string]: TValue},
-  mapper: (value: TValue, key: string) => TNext,
+  mapper: (value: TValue, key: string) => TNext
 ): {[key: string]: TNext} {
   return Object.keys(object).reduce(
     (result, key) => {
       result[key] = mapper(object[key], key);
       return result;
     },
-    {},
+    {}
   );
 }

--- a/src/plugins/check-props-plugin.js
+++ b/src/plugins/check-props-plugin.js
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV !== 'production') {
       'backgroundRepeat',
       'backgroundRepeatX',
       'backgroundRepeatY',
-      'backgroundSize',
+      'backgroundSize'
     ],
     border: [
       'borderBottom',
@@ -44,20 +44,20 @@ if (process.env.NODE_ENV !== 'production') {
       'borderTopColor',
       'borderTopStyle',
       'borderTopWidth',
-      'borderWidth',
+      'borderWidth'
     ],
     borderImage: [
       'borderImageOutset',
       'borderImageRepeat',
       'borderImageSlice',
       'borderImageSource',
-      'borderImageWidth',
+      'borderImageWidth'
     ],
     borderRadius: [
       'borderBottomLeftRadius',
       'borderBottomRightRadius',
       'borderTopLeftRadius',
-      'borderTopRightRadius',
+      'borderTopRightRadius'
     ],
     font: [
       'fontFamily',
@@ -68,7 +68,7 @@ if (process.env.NODE_ENV !== 'production') {
       'fontVariant',
       'fontVariantLigatures',
       'fontWeight',
-      'lineHeight',
+      'lineHeight'
     ],
     listStyle: ['listStyleImage', 'listStylePosition', 'listStyleType'],
     margin: ['marginBottom', 'marginLeft', 'marginRight', 'marginTop'],
@@ -77,8 +77,8 @@ if (process.env.NODE_ENV !== 'production') {
       'transitionDelay',
       'transitionDuration',
       'transitionProperty',
-      'transitionTimingFunction',
-    ],
+      'transitionTimingFunction'
+    ]
   };
 
   checkProps = function(config: PluginConfig): PluginResult {
@@ -92,7 +92,7 @@ if (process.env.NODE_ENV !== 'production') {
       if (
         Array.isArray(shorthandPropertyExpansions[styleKey]) &&
         shorthandPropertyExpansions[styleKey].some(
-          sp => styleKeys.indexOf(sp) !== -1,
+          sp => styleKeys.indexOf(sp) !== -1
         )
       ) {
         if (process.env.NODE_ENV !== 'production') {
@@ -106,7 +106,7 @@ if (process.env.NODE_ENV !== 'production') {
               componentName +
               '.',
             'See https://github.com/FormidableLabs/radium/issues/95 for more ' +
-              'information.',
+              'information.'
           );
           /* eslint-enable no-console */
         }

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -30,7 +30,7 @@ export type PluginConfig = {
   cssRuleSetToString: (
     selector: string,
     rules: Object,
-    userAgent: ?string,
+    userAgent: ?string
   ) => string,
 
   // Retrieve the value of a field on the component
@@ -71,8 +71,8 @@ export type PluginConfig = {
   // uses the exenv npm module
   ExecutionEnvironment: {
     canUseEventListeners: boolean,
-    canUseDOM: boolean,
-  },
+    canUseDOM: boolean
+  }
 };
 
 export type PluginResult = ?{
@@ -88,7 +88,7 @@ export type PluginResult = ?{
   props?: ?Object,
 
   // Replaces (not merged into) the rendered element's style property.
-  style?: ?Object,
+  style?: ?Object
 };
 
 export default {
@@ -99,5 +99,5 @@ export default {
   removeNestedStyles: removeNestedStylesPlugin,
   resolveInteractionStyles: resolveInteractionStylesPlugin,
   resolveMediaQueries: resolveMediaQueriesPlugin,
-  visited: visitedPlugin,
+  visited: visitedPlugin
 };

--- a/src/plugins/keyframes-plugin.js
+++ b/src/plugins/keyframes-plugin.js
@@ -4,7 +4,7 @@ import type {PluginConfig, PluginResult} from './index';
 import type {Keyframes} from '../keyframes';
 
 export default function keyframesPlugin(
-  {addCSS, config, style}: PluginConfig, // eslint-disable-line no-shadow
+  {addCSS, config, style}: PluginConfig // eslint-disable-line no-shadow
 ): PluginResult {
   const newStyle = Object.keys(style).reduce(
     (newStyleInProgress, key) => {
@@ -19,7 +19,7 @@ export default function keyframesPlugin(
       newStyleInProgress[key] = value;
       return newStyleInProgress;
     },
-    {},
+    {}
   );
   return {style: newStyle};
 }

--- a/src/plugins/merge-style-array-plugin.js
+++ b/src/plugins/merge-style-array-plugin.js
@@ -7,8 +7,8 @@ import type {PluginConfig, PluginResult} from './index';
 const mergeStyleArrayPlugin = function(
   {
     style,
-    mergeStyles,
-  }: PluginConfig,
+    mergeStyles
+  }: PluginConfig
 ): PluginResult {
   // eslint-disable-line no-shadow
   const newStyle = Array.isArray(style) ? mergeStyles(style) : style;

--- a/src/plugins/mouse-up-listener.js
+++ b/src/plugins/mouse-up-listener.js
@@ -28,11 +28,11 @@ const subscribe = function(callback: () => void): {remove: () => void} {
         window.removeEventListener('mouseup', _handleMouseUp);
         _mouseUpListenerIsActive = false;
       }
-    },
+    }
   };
 };
 
 export default {
   subscribe: subscribe,
-  __triggerForTests: _handleMouseUp,
+  __triggerForTests: _handleMouseUp
 };

--- a/src/plugins/prefix-plugin.js
+++ b/src/plugins/prefix-plugin.js
@@ -5,7 +5,7 @@ import type {PluginConfig, PluginResult} from './index';
 import {getPrefixedStyle} from '../prefixer';
 
 export default function prefixPlugin(
-  {config, style}: PluginConfig, // eslint-disable-line no-shadow
+  {config, style}: PluginConfig // eslint-disable-line no-shadow
 ): PluginResult {
   const newStyle = getPrefixedStyle(style, config.userAgent);
   return {style: newStyle};

--- a/src/plugins/remove-nested-styles-plugin.js
+++ b/src/plugins/remove-nested-styles-plugin.js
@@ -5,8 +5,8 @@ import type {PluginConfig, PluginResult} from './index';
 export default function removeNestedStyles(
   {
     isNestedStyle,
-    style,
-  }: PluginConfig,
+    style
+  }: PluginConfig
 ): PluginResult {
   // eslint-disable-line no-shadow
   const newStyle = Object.keys(style).reduce(
@@ -17,10 +17,10 @@ export default function removeNestedStyles(
       }
       return newStyleInProgress;
     },
-    {},
+    {}
   );
 
   return {
-    style: newStyle,
+    style: newStyle
   };
 }

--- a/src/plugins/resolve-interaction-styles-plugin.js
+++ b/src/plugins/resolve-interaction-styles-plugin.js
@@ -18,7 +18,7 @@ const resolveInteractionStyles = function(config: PluginConfig): PluginResult {
     mergeStyles,
     props,
     setState,
-    style,
+    style
   } = config;
 
   const newComponentFields = {};
@@ -89,13 +89,13 @@ const resolveInteractionStyles = function(config: PluginConfig): PluginResult {
     newComponentFields._radiumMouseUpListener = MouseUpListener.subscribe(
       () => {
         Object.keys(
-          getComponentField('state')._radiumStyleState,
+          getComponentField('state')._radiumStyleState
         ).forEach(key => {
           if (getState(':active', key) === 'viamousedown') {
             setState(':active', false, key);
           }
         });
-      },
+      }
     );
   }
 
@@ -116,13 +116,13 @@ const resolveInteractionStyles = function(config: PluginConfig): PluginResult {
       }
       return styleWithoutInteractions;
     },
-    {},
+    {}
   );
 
   return {
     componentFields: newComponentFields,
     props: newProps,
-    style: newStyle,
+    style: newStyle
   };
 };
 

--- a/src/plugins/resolve-media-queries-plugin.js
+++ b/src/plugins/resolve-media-queries-plugin.js
@@ -17,11 +17,11 @@ function _getWindowMatchMedia(ExecutionEnvironment) {
 
 function _filterObject(
   obj: Object,
-  predicate: (value: any, key: string) => boolean,
+  predicate: (value: any, key: string) => boolean
 ): Object {
   return Object.keys(obj).filter(key => predicate(obj[key], key)).reduce((
     result,
-    key,
+    key
   ) => {
     result[key] = obj[key];
     return result;
@@ -36,7 +36,7 @@ function _removeMediaQueries(style) {
       }
       return styleWithoutMedia;
     },
-    {},
+    {}
   );
 }
 
@@ -48,13 +48,13 @@ function _topLevelRulesToCSS(
     hash,
     isNestedStyle,
     style,
-    userAgent,
-  },
+    userAgent
+  }
 ) {
   let className = '';
   Object.keys(style).filter(name => name.indexOf('@media') === 0).map(query => {
     const topLevelRules = appendImportantToEachValue(
-      _filterObject(style[query], value => !isNestedStyle(value)),
+      _filterObject(style[query], value => !isNestedStyle(value))
     );
 
     if (!Object.keys(topLevelRules).length) {
@@ -80,8 +80,8 @@ function _subscribeToMediaQuery(
     listenersByQuery,
     matchMedia,
     mediaQueryListsByQuery,
-    query,
-  },
+    query
+  }
 ) {
   query = query.replace('@media ', '');
 
@@ -96,7 +96,7 @@ function _subscribeToMediaQuery(
     listenersByQuery[query] = {
       remove() {
         mql.removeListener(listener);
-      },
+      }
     };
   }
   return mql;
@@ -116,8 +116,8 @@ export default function resolveMediaQueries(
     mergeStyles,
     props,
     setState,
-    style,
-  }: PluginConfig,
+    style
+  }: PluginConfig
 ): PluginResult {
   // eslint-disable-line no-shadow
   let newStyle = _removeMediaQueries(style);
@@ -128,13 +128,13 @@ export default function resolveMediaQueries(
     hash,
     isNestedStyle,
     style,
-    userAgent: config.userAgent,
+    userAgent: config.userAgent
   });
 
   const newProps = mediaQueryClassNames
     ? {
         className: mediaQueryClassNames +
-          (props.className ? ' ' + props.className : ''),
+          (props.className ? ' ' + props.className : '')
       }
     : null;
 
@@ -144,12 +144,12 @@ export default function resolveMediaQueries(
   if (!matchMedia) {
     return {
       props: newProps,
-      style: newStyle,
+      style: newStyle
     };
   }
 
   const listenersByQuery = {
-    ...getComponentField('_radiumMediaQueryListenersByQuery'),
+    ...getComponentField('_radiumMediaQueryListenersByQuery')
   };
   const mediaQueryListsByQuery = getGlobalState('mediaQueryListsByQuery') || {};
 
@@ -165,7 +165,7 @@ export default function resolveMediaQueries(
       listenersByQuery,
       matchMedia,
       mediaQueryListsByQuery,
-      query,
+      query
     });
 
     // Apply media query states
@@ -176,10 +176,10 @@ export default function resolveMediaQueries(
 
   return {
     componentFields: {
-      _radiumMediaQueryListenersByQuery: listenersByQuery,
+      _radiumMediaQueryListenersByQuery: listenersByQuery
     },
     globalState: {mediaQueryListsByQuery},
     props: newProps,
-    style: newStyle,
+    style: newStyle
   };
 }

--- a/src/plugins/visited-plugin.js
+++ b/src/plugins/visited-plugin.js
@@ -10,8 +10,8 @@ export default function visited(
     cssRuleSetToString,
     hash,
     props,
-    style,
-  }: PluginConfig,
+    style
+  }: PluginConfig
 ): PluginResult {
   // eslint-disable-line no-shadow
   let className = props.className;
@@ -33,11 +33,11 @@ export default function visited(
 
       return newStyleInProgress;
     },
-    {},
+    {}
   );
 
   return {
     props: className === props.className ? null : {className},
-    style: newStyle,
+    style: newStyle
   };
 }

--- a/src/prefixer.js
+++ b/src/prefixer.js
@@ -24,7 +24,7 @@ function transformValues(style) {
       newStyle[key] = value;
       return newStyle;
     },
-    {},
+    {}
   );
 }
 
@@ -33,10 +33,10 @@ let _lastUserAgent;
 let _cachedPrefixer;
 
 function getPrefixer(
-  userAgent: ?string,
+  userAgent: ?string
 ): {
   +prefix: (style: Object) => Object,
-  prefixedKeyframes: string,
+  prefixedKeyframes: string
 } {
   const actualUserAgent = userAgent ||
     (global && global.navigator && global.navigator.userAgent);
@@ -47,7 +47,7 @@ function getPrefixer(
       console.warn(
         'Radium: userAgent should be supplied for server-side rendering. See ' +
           'https://github.com/FormidableLabs/radium/tree/master/docs/api#radium ' +
-          'for more information.',
+          'for more information.'
       );
       /* eslint-enable no-console */
       _hasWarnedAboutUserAgent = true;
@@ -58,7 +58,7 @@ function getPrefixer(
     if (actualUserAgent === 'all') {
       _cachedPrefixer = {
         prefix: InlineStylePrefixer.prefixAll,
-        prefixedKeyframes: 'keyframes',
+        prefixedKeyframes: 'keyframes'
       };
     } else {
       _cachedPrefixer = new InlineStylePrefixer({userAgent: actualUserAgent});

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -23,8 +23,8 @@ const DEFAULT_CONFIG = {
     Plugins.visited,
     Plugins.removeNestedStyles,
     Plugins.prefix,
-    Plugins.checkProps,
-  ],
+    Plugins.checkProps
+  ]
 };
 
 // Gross
@@ -36,7 +36,7 @@ let resolveStyles = ((null: any): (
   renderedElement: any,
   config: Config,
   existingKeyMap?: {[key: string]: boolean},
-  shouldCheckBeforeResolve: true,
+  shouldCheckBeforeResolve: true
 ) => any);
 
 const _shouldResolveStyles = function(component) {
@@ -48,8 +48,8 @@ const _resolveChildren = function(
     children,
     component,
     config,
-    existingKeyMap,
-  },
+    existingKeyMap
+  }
 ) {
   if (!children) {
     return children;
@@ -95,8 +95,8 @@ const _resolveProps = function(
     component,
     config,
     existingKeyMap,
-    props,
-  },
+    props
+  }
 ) {
   let newProps = props;
 
@@ -114,7 +114,7 @@ const _resolveProps = function(
         propValue,
         config,
         existingKeyMap,
-        true,
+        true
       );
     }
   });
@@ -126,8 +126,8 @@ const _buildGetKey = function(
   {
     componentName,
     existingKeyMap,
-    renderedElement,
-  },
+    renderedElement
+  }
 ) {
   // We need a unique key to correlate state changes due to user interaction
   // with the rendered element, so we know to apply the proper interactive
@@ -164,7 +164,7 @@ const _buildGetKey = function(
           'Component: "' +
           componentName +
           '". ' +
-          (elementName ? 'Element: "' + elementName + '".' : ''),
+          (elementName ? 'Element: "' + elementName + '".' : '')
       );
     }
 
@@ -198,8 +198,8 @@ const _runPlugins = function(
     config,
     existingKeyMap,
     props,
-    renderedElement,
-  },
+    renderedElement
+  }
 ) {
   // Don't run plugins if renderedElement is not a simple ReactDOMElement or has
   // no style.
@@ -220,7 +220,7 @@ const _runPlugins = function(
   const getKey = _buildGetKey({
     renderedElement,
     existingKeyMap,
-    componentName,
+    componentName
   });
   const getComponentField = key => component[key];
   const getGlobalState = key => globalState[key];
@@ -242,7 +242,7 @@ const _runPlugins = function(
           'please wrap your application in the StyleRoot component. Component ' +
           'name: `' +
           componentName +
-          '`.',
+          '`.'
       );
     }
 
@@ -267,7 +267,7 @@ const _runPlugins = function(
       props: newProps,
       setState,
       isNestedStyle,
-      style: newStyle,
+      style: newStyle
     }) || {};
 
     newStyle = result.style || newStyle;
@@ -318,7 +318,7 @@ resolveStyles = function(
   renderedElement: any, // ReactElement
   config: Config = DEFAULT_CONFIG,
   existingKeyMap?: {[key: string]: boolean},
-  shouldCheckBeforeResolve: boolean = false,
+  shouldCheckBeforeResolve: boolean = false
 ): any {
   // ReactElement
   existingKeyMap = existingKeyMap || {};
@@ -340,14 +340,14 @@ resolveStyles = function(
     children: renderedElement.props.children,
     component,
     config,
-    existingKeyMap,
+    existingKeyMap
   });
 
   let newProps = _resolveProps({
     component,
     config,
     existingKeyMap,
-    props: renderedElement.props,
+    props: renderedElement.props
   });
 
   newProps = _runPlugins({
@@ -355,7 +355,7 @@ resolveStyles = function(
     config,
     existingKeyMap,
     props: newProps,
-    renderedElement,
+    renderedElement
   });
 
   // If nothing changed, don't bother cloning the element. Might be a bit
@@ -371,7 +371,7 @@ resolveStyles = function(
   return _cloneElement(
     renderedElement,
     newProps !== renderedElement.props ? newProps : {},
-    newChildren,
+    newChildren
   );
 };
 

--- a/src/style-keeper.js
+++ b/src/style-keeper.js
@@ -23,7 +23,7 @@ export default class StyleKeeper {
         if (listenerIndex > -1) {
           this._listeners.splice(listenerIndex, 1);
         }
-      },
+      }
     };
   }
 
@@ -38,7 +38,7 @@ export default class StyleKeeper {
       remove: () => {
         delete this._cssSet[css];
         this._emitChange();
-      },
+      }
     };
   }
 

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -12,7 +12,7 @@ export function getRenderOutput(element) {
 
 export function getElement(output, tagName) {
   return ReactDOM.findDOMNode(
-    TestUtils.findRenderedDOMComponentWithTag(output, tagName),
+    TestUtils.findRenderedDOMComponentWithTag(output, tagName)
   );
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,22 +9,22 @@ module.exports = {
         root: 'React',
         commonjs2: 'react',
         commonjs: 'react',
-        amd: 'react',
-      },
-    },
+        amd: 'react'
+      }
+    }
   ],
   output: {
     path: path.join(__dirname, '/dist'),
     filename: 'radium.js',
     library: 'Radium',
-    libraryTarget: 'umd',
+    libraryTarget: 'umd'
   },
   module: {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel-loader',
-      },
-    ],
-  },
+        loader: 'babel-loader'
+      }
+    ]
+  }
 };

--- a/webpack.config.minified.js
+++ b/webpack.config.minified.js
@@ -3,19 +3,19 @@ const merge = require('lodash.merge');
 
 module.exports = merge({}, require('./webpack.config.js'), {
   output: {
-    filename: 'radium.min.js',
+    filename: 'radium.min.js'
   },
   plugins: [
     new webpack.optimize.UglifyJsPlugin({
       compress: {
-        warnings: false,
-      },
+        warnings: false
+      }
     }),
     new webpack.DefinePlugin({
       'process.env': {
         // Signal production mode for React JS and other libs.
-        NODE_ENV: JSON.stringify('production'),
-      },
-    }),
-  ],
+        NODE_ENV: JSON.stringify('production')
+      }
+    })
+  ]
 });


### PR DESCRIPTION
Trailing commas add no "value" for correctness, and their absence is "always correct" for thing like older version of Node. Now that we actually lint _all_ our JS files in Radium, it is easier to just remove trailing commas in lint than have different lint for transpiled `src` vs. "real node" root `*.js` files like webpack configs, etc.

Fixes #932

/cc @alexlande 