### PR TITLE
Remove decorator recommendations/examples from the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For a short technical explanation, see [How does Radium work?](#how-does-radium-
 
 ## Usage
 
-Start by adding the `@Radium` decorator to your component class. Alternatively, wrap `Radium()` around your component, like `module.exports = Radium(Component)`, or `Component = Radium(Component)`, which works with classes, `createClass`, and stateless components (functions that take props and return a ReactElement). Then, write a style object as you normally would with inline styles, and add in styles for interactive states and media queries. Pass the style object to your component via `style={...}` and let Radium do the rest!
+Start by wrapping your component class with `Radium()`, like `module.exports = Radium(Component)`, or `Component = Radium(Component)`, which works with classes, `createClass`, and stateless components (functions that take props and return a ReactElement). Then, write a style object as you normally would with inline styles, and add in styles for interactive states and media queries. Pass the style object to your component via `style={...}` and let Radium do the rest!
 
 ```jsx
 <Button kind="primary">Radium Button</Button>
@@ -60,7 +60,6 @@ var Radium = require('radium');
 var React = require('react');
 var color = require('color');
 
-@Radium
 class Button extends React.Component {
   static propTypes = {
     kind: PropTypes.oneOf(['primary', 'warning']).isRequired
@@ -83,6 +82,8 @@ class Button extends React.Component {
     );
   }
 }
+
+Button = Radium(Button);
 
 // You can create your style objects dynamically or share them for
 // every instance of the component.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -82,11 +82,12 @@ var styles = {
 - Process the `style` attribute after `render()`
 - Clean up any resources when the component unmounts
 
-Usage with `class` and ES7 decorators:
+Usage with `class`:
 
 ```jsx
-@Radium
 class MyComponent extends React.Component { ... }
+
+MyComponent = Radium(MyComponent);
 ```
 
 Usage with `createClass`:
@@ -100,11 +101,12 @@ module.exports = Radium(MyComponent);
 - Merge arrays of styles passed as the `style` attribute
 - Automatically vendor prefix the `style` object
 
-You can also pass a configuration object to `@Radium`:
+You can also pass a configuration object to `Radium`:
 
 ```jsx
-@Radium({matchMedia: mockMatchMedia})
 class MyComponent extends React.Component { ... }
+
+MyComponent = Radium({matchMedia: mockMatchMedia})(MyComponent);
 
 // or with createClass
 
@@ -113,7 +115,7 @@ module.exports = Radium({matchMedia: mockMatchMedia})(MyComponent);
 ```
 
 You may want to have project-wide Radium settings. Simply create a function that
-wraps Radium, and use it instead of `@Radium`:
+wraps Radium, and use it instead of `Radium`:
 
 ```jsx
 function ConfiguredRadium(component) {
@@ -121,8 +123,9 @@ function ConfiguredRadium(component) {
 }
 
 // Usage
-@ConfiguredRadium
 class MyComponent extends React.Component { ... }
+
+MyComponent = ConfiguredRadium(MyComponent);
 ```
 
 Radium can be called any number of times with a config object, and later configs
@@ -130,8 +133,9 @@ will be merged with and overwrite previous configs. That way, you can still
 override settings on a per-component basis:
 
 ```jsx
-@ConfiguredRadium(config)
 class MySpecialComponent extends React.Component { ... }
+
+MySpecialComponent = ConfiguredRadium(config)(MySpecialComponent);
 ```
 
 Alternatively, if the config value can change every time the component is rendered (userAgent, for example), you can pass configuration to any component wrapped in `Radium` using the `radiumConfig` prop:
@@ -165,7 +169,7 @@ app.get('/app/:width/:height', function(req, res) {
     height: req.params.height,
   });
 
-  // Your application code uses `@ConfiguredRadium` instead of `@Radium`
+  // Your application code uses `ConfiguredRadium` instead of `Radium`
   var html = React.renderToString(<RadiumApp />);
 
   res.end(html);
@@ -197,8 +201,9 @@ module.exports = ConfiguredRadium;
 ```jsx
 var ConfiguredRadium = require('./configured-radium');
 
-@ConfiguredRadium
 class MyComponent extends React.Component { ... }
+
+MyComponent = ConfiguredRadium(MyComponent);
 ```
 
 See [#146](https://github.com/FormidableLabs/radium/pull/146) for more info.
@@ -233,8 +238,9 @@ function ConfiguredRadium(component) {
 }
 
 // Usage
-@ConfiguredRadium
 class MyComponent extends React.Component { ... }
+
+MyComponent = ConfiguredRadium(MyComponent);
 ```
 
 You will typically want to put plugins before the final `checkProps` so that you can still benefit from the checks it provides. If your plugin might produce other pseudo-style blocks, like `@media` consumed by `resolveMediaQueries` or `:hover` consumed by `resolveInteractionStyles`, you would want to have your plugin run before those plugins.
@@ -284,7 +290,6 @@ Create a keyframes animation for use in an inline style. `keyframes` returns an 
 `keyframes` takes an optional second parameter, a `name` to prepend to the animation's name to aid in debugging.
 
 ```jsx
-@Radium
 class Spinner extends React.Component {
   render () {
     return (
@@ -294,6 +299,8 @@ class Spinner extends React.Component {
     );
   }
 }
+
+Spinner = Radium(Spinner);
 
 var pulseKeyframes = Radium.keyframes({
   '0%': {width: '10%'},

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -50,7 +50,6 @@ var droids = [
   'Probe Droid'
 ];
 
-@Radium
 class DroidList extends React.Component {
   render() {
     return (
@@ -76,6 +75,8 @@ class DroidList extends React.Component {
     );
   }
 }
+
+DroidList = Radium(DroidList);
 ```
 
 Instead of `:before` and `:after`, add extra elements when rendering your HTML.
@@ -107,7 +108,6 @@ The example from the main Readme (using regular CSS syntax)
 ```jsx
 import styler from 'react-styling/flat'
 
-@Radium
 class Button extends React.Component {
   static propTypes = {
     kind: PropTypes.oneOf(['primary', 'warning']).isRequired
@@ -121,6 +121,8 @@ class Button extends React.Component {
     )
   }
 }
+
+Button = Radium(Button);
 
 const style = styler`
   .button {
@@ -183,6 +185,6 @@ Make sure it is a real user agent that `inline-style-prefixer` recognizes, or yo
 
 ## Why do React warnings have the wrong component name?
 
-You may see the name "Constructor" instead of your component name, for example: "Warning: Failed propType: Invalid prop `onClick` of type `function` supplied to `Constructor`, expected `string`." or "Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Constructor`." 
+You may see the name "Constructor" instead of your component name, for example: "Warning: Failed propType: Invalid prop `onClick` of type `function` supplied to `Constructor`, expected `string`." or "Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `Constructor`."
 
 Your transpiler is probably not able to set the `displayName` property of the component correctly, which can happen if you wrap `React.createClass` immediately with `Radium`, e.g. `var Button = Radium(React.createClass({ ... }));`. Instead, wrap your component afterward, ex. `Button = Radium(Button);`,  or when exporting, ex. `module.exports = Radium(Button);`, or set `displayName` manually.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -43,16 +43,9 @@ class Button extends React.Component {
 }
 ```
 
-Radium is activated by using a decorator or wrapping your component:
+Radium is activated by wrapping your component:
 
 ```jsx
-// For ES6 and ES7
-@Radium
-class Button extends React.Component {
-  // ...
-}
-
-// or
 class Button extends React.Component {
   // ...
 }


### PR DESCRIPTION
This is a simple change that replaces decorators with wrapping everywhere in the docs. Decorators are no longer mentioned at all. Fixes #924.

@alexlande Do we want to at least *mention* decorators somewhere in the docs? (If so, where?) 