### PR TITLE
[WIP] clear radium state for unmounted components

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -95,23 +95,35 @@ const VisitedLink = Radium(() => (
   render() {
     return (
       <div>
-        <button onClick={() => this.setState({ showButton: true })}>Show</button>
-        {this.state.showButton && (
-          <button
-            onClick={() => this.setState({ showButton: false })}
-            style={hideButtonStyle}
-          >
-            Hide
-          </button>
-        )}
+        <button key={0} onClick={() => this.setState({ showButton: true })}>Show</button>
+        <div>
+          {this.state.showButton && (
+            <button
+              key={1}
+              onClick={() => this.setState({ showButton: false })}
+              style={hideButtonStyle.hoverButton}
+            >
+              Hide
+            </button>
+          )}
+        </div>
+        <button key={2} style={hideButtonStyle.focusButton}>Focus</button>
+        <button key={3}>Extra</button>
       </div>
     );
   }
 }
 
 const hideButtonStyle = {
-  ':hover': {
-    background: 'red'
+  hoverButton: {
+    ':hover': {
+      background: 'red'
+    }
+  },
+  focusButton: {
+    ':focus': {
+      background: 'blue'
+    }
   }
 };
 
@@ -134,6 +146,7 @@ class App extends React.Component {
 
     return (
       <StyleRoot>
+        {/*
         <VisitedLink />
 
         <p /><HoverMessage />
@@ -210,6 +223,7 @@ class App extends React.Component {
           />
           <span>This content has scoped styles</span>
         </div>
+        */}
 
         <HideButton />
       </StyleRoot>

--- a/examples/app.js
+++ b/examples/app.js
@@ -86,6 +86,35 @@ const VisitedLink = Radium(() => (
   </a>
 ));
 
+@Radium class HideButton extends React.Component {
+  constructor() {
+    super();
+    this.state = { showButton: true };
+  }
+
+  render() {
+    return (
+      <div>
+        <button onClick={() => this.setState({ showButton: true })}>Show</button>
+        {this.state.showButton && (
+          <button
+            onClick={() => this.setState({ showButton: false })}
+            style={hideButtonStyle}
+          >
+            Hide
+          </button>
+        )}
+      </div>
+    );
+  }
+}
+
+const hideButtonStyle = {
+  ':hover': {
+    background: 'red'
+  }
+};
+
 class App extends React.Component {
   _remount() {
     this.setState({shouldRenderNull: true});
@@ -181,6 +210,8 @@ class App extends React.Component {
           />
           <span>This content has scoped styles</span>
         </div>
+
+        <HideButton />
       </StyleRoot>
     );
   }

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -175,6 +175,21 @@ export default function enhanceWithRadium(
       return newContext;
     }
 
+    componentDidUpdate() {
+      const radiumState = this.state._radiumStyleState;
+
+      if (!Object.keys(radiumState).every((key) => this.childKeys[key])) {
+        const trimmedRadiumState = Object.keys(this.childKeys).reduce((acc, key) => {
+          if (radiumState[key]) {
+            acc[key] = radiumState[key];
+          }
+          return acc;
+        }, {});
+
+        this.setState({ _radiumStyleState: trimmedRadiumState });
+      }
+    }
+
     render() {
       const renderedElement = super.render();
       let currentConfig = this.props.radiumConfig ||
@@ -188,7 +203,10 @@ export default function enhanceWithRadium(
         };
       }
 
-      return resolveStyles(this, renderedElement, currentConfig);
+      const { childKeys, element } = resolveStyles(this, renderedElement, currentConfig);
+      this.childKeys = childKeys;
+
+      return element;
     }
   }
 


### PR DESCRIPTION
Initial attempt to resolve https://github.com/FormidableLabs/radium/issues/524.

1. Keep track of children keys when going through them recursively in `resolve-styles.js`
2. Check these keys against the state in `enhancer.js`
3. Remove the keys in the state that correspond with unmounted components in `enhancer.js`

There is still a lot of cleanup to do, but I'm looking for opinions on the approach.