### PR TITLE
Support ES7 arrow functions on React classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Radium Changelog
 
+## Unreleased
+- Support ES7 arrow functions for React class methods. (#738)
+
 ## 0.22.1 (March 1, 2018)
 - Fix `keyframes` bug from prefixed inline styles. (#973)
 

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -742,10 +742,14 @@ describe('Radium blackbox tests', () => {
       };
     }
 
-    TestComponent = Radium(TestComponent);
+    const Wrapped = Radium(TestComponent);
     const output = TestUtils.renderIntoDocument(
-      <TestComponent>hello world</TestComponent>
+      <Wrapped>hello world</Wrapped>
     );
+
+    // Check prototype is not mutated.
+    expect(TestComponent.prototype).to.not.have.property("render");
+
     const div = getElement(output, 'div');
 
     expect(div.style.color).to.equal('blue');
@@ -770,10 +774,16 @@ describe('Radium blackbox tests', () => {
       };
     }
 
-    TestComponent = Radium(TestComponent);
+    const Wrapped = Radium(TestComponent);
     const output = TestUtils.renderIntoDocument(
-      <TestComponent>hello world</TestComponent>
+      <Wrapped>hello world</Wrapped>
     );
+
+    // Check prototypes are not mutated.
+    expect(First.prototype).to.not.have.property("render");
+    expect(Second.prototype).to.not.have.property("render");
+    expect(TestComponent.prototype).to.not.have.property("render");
+
     const div = getElement(output, 'div');
 
     expect(div.style.color).to.equal('blue');

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -739,7 +739,7 @@ describe('Radium blackbox tests', () => {
             {this.props.children}
           </div>
         );
-      }
+      };
     }
 
     TestComponent = Radium(TestComponent);
@@ -757,11 +757,11 @@ describe('Radium blackbox tests', () => {
   });
 
   // Regression test: https://github.com/FormidableLabs/radium/issues/738
-  it.only('works with arrow-based render methods in components with complex inheritence', () => {
+  it('works with arrow-based render methods in components with complex inheritence', () => {
     class First extends Component {}
     class Second extends First {}
     class TestComponent extends Second {
-      render() {
+      render = () => {
         return (
           <div style={{color: 'blue', ':hover': {color: 'red'}}}>
             {this.props.children}

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -731,9 +731,37 @@ describe('Radium blackbox tests', () => {
   });
 
   // Regression test: https://github.com/FormidableLabs/radium/issues/738
-  it.only('works with arrow-based render methods in components', () => {
+  it('works with arrow-based render methods in components', () => {
     class TestComponent extends Component {
       render = () => {
+        return (
+          <div style={{color: 'blue', ':hover': {color: 'red'}}}>
+            {this.props.children}
+          </div>
+        );
+      }
+    }
+
+    TestComponent = Radium(TestComponent);
+    const output = TestUtils.renderIntoDocument(
+      <TestComponent>hello world</TestComponent>
+    );
+    const div = getElement(output, 'div');
+
+    expect(div.style.color).to.equal('blue');
+    expect(div.innerText).to.equal('hello world');
+
+    TestUtils.SimulateNative.mouseOver(div);
+
+    expect(div.style.color).to.equal('red');
+  });
+
+  // Regression test: https://github.com/FormidableLabs/radium/issues/738
+  it.only('works with arrow-based render methods in components with complex inheritence', () => {
+    class First extends Component {}
+    class Second extends First {}
+    class TestComponent extends Second {
+      render() {
         return (
           <div style={{color: 'blue', ':hover': {color: 'red'}}}>
             {this.props.children}

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -731,7 +731,7 @@ describe('Radium blackbox tests', () => {
   });
 
   // Regression test: https://github.com/FormidableLabs/radium/issues/738
-  it('works with arrow-based render methods in components', () => {
+  it.only('works with arrow-based render methods in components', () => {
     class TestComponent extends Component {
       render = () => {
         return (
@@ -746,6 +746,9 @@ describe('Radium blackbox tests', () => {
     const output = TestUtils.renderIntoDocument(
       <TestComponent>hello world</TestComponent>
     );
+    // TOOD HERE -- Render is wrong
+    console.log("TOOD HERE RENDERED", output);
+
     const div = getElement(output, 'div');
 
     expect(div.style.color).to.equal('blue');

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -743,12 +743,10 @@ describe('Radium blackbox tests', () => {
     }
 
     const Wrapped = Radium(TestComponent);
-    const output = TestUtils.renderIntoDocument(
-      <Wrapped>hello world</Wrapped>
-    );
+    const output = TestUtils.renderIntoDocument(<Wrapped>hello world</Wrapped>);
 
     // Check prototype is not mutated.
-    expect(TestComponent.prototype).to.not.have.property("render");
+    expect(TestComponent.prototype).to.not.have.property('render');
 
     const div = getElement(output, 'div');
 
@@ -775,14 +773,12 @@ describe('Radium blackbox tests', () => {
     }
 
     const Wrapped = Radium(TestComponent);
-    const output = TestUtils.renderIntoDocument(
-      <Wrapped>hello world</Wrapped>
-    );
+    const output = TestUtils.renderIntoDocument(<Wrapped>hello world</Wrapped>);
 
     // Check prototypes are not mutated.
-    expect(First.prototype).to.not.have.property("render");
-    expect(Second.prototype).to.not.have.property("render");
-    expect(TestComponent.prototype).to.not.have.property("render");
+    expect(First.prototype).to.not.have.property('render');
+    expect(Second.prototype).to.not.have.property('render');
+    expect(TestComponent.prototype).to.not.have.property('render');
 
     const div = getElement(output, 'div');
 

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -746,9 +746,6 @@ describe('Radium blackbox tests', () => {
     const output = TestUtils.renderIntoDocument(
       <TestComponent>hello world</TestComponent>
     );
-    // TOOD HERE -- Render is wrong
-    console.log("TOOD HERE RENDERED", output);
-
     const div = getElement(output, 'div');
 
     expect(div.style.color).to.equal('blue');

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -731,7 +731,7 @@ describe('Radium blackbox tests', () => {
   });
 
   // Regression test: https://github.com/FormidableLabs/radium/issues/738
-  it.only('works with arrow-based render methods in components', () => {
+  it('works with arrow-based render methods in components', () => {
     class TestComponent extends Component {
       render = () => {
         return (
@@ -767,7 +767,7 @@ describe('Radium blackbox tests', () => {
             {this.props.children}
           </div>
         );
-      }
+      };
     }
 
     TestComponent = Radium(TestComponent);

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -730,6 +730,32 @@ describe('Radium blackbox tests', () => {
     expect(div.style.color).to.equal('red');
   });
 
+  // Regression test: https://github.com/FormidableLabs/radium/issues/738
+  it.only('works with arrow-based render methods in components', () => {
+    class TestComponent extends Component {
+      render = () => {
+        return (
+          <div style={{color: 'blue', ':hover': {color: 'red'}}}>
+            {this.props.children}
+          </div>
+        );
+      }
+    }
+
+    TestComponent = Radium(TestComponent);
+    const output = TestUtils.renderIntoDocument(
+      <TestComponent>hello world</TestComponent>
+    );
+    const div = getElement(output, 'div');
+
+    expect(div.style.color).to.equal('blue');
+    expect(div.innerText).to.equal('hello world');
+
+    TestUtils.SimulateNative.mouseOver(div);
+
+    expect(div.style.color).to.equal('red');
+  });
+
   it('works fine if passing null, undefined, or false in style', () => {
     const TestComponent = Radium(() => (
       <div style={{background: undefined, border: false, color: null}} />

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -161,19 +161,23 @@ export default function enhanceWithRadium(
       // (Using a copy of the class).
       // See: https://github.com/FormidableLabs/radium/issues/738
       RADIUM_METHODS.forEach(name => {
-        const thisDesc = Object.getOwnPropertyDescriptor(this, name);
+        const thisDesc = Object.getOwnPropertyDescriptor(self, name);
         const thisMethod = (thisDesc || {}).value;
+
+        // Only care if have instance method.
+        if (!thisMethod) {
+          return;
+        }
+
         const radiumDesc = Object.getOwnPropertyDescriptor(RADIUM_PROTO, name);
         const radiumProtoMethod = radiumDesc.value;
         const superProtoMethod = ComposedComponent.prototype[name];
 
-        // Start looking when:
+        // Allow transfer when:
         // 1. have an instance method
         // 2. the super class prototype doesn't have any method
         // 3. it is not already the radium prototype's
-        if (
-          thisMethod && !superProtoMethod && thisMethod !== radiumProtoMethod
-        ) {
+        if (!superProtoMethod && thisMethod !== radiumProtoMethod) {
           // Transfer dynamic render component to Component prototype (copy).
           Object.defineProperty(ComposedComponent.prototype, name, thisDesc);
 

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -31,10 +31,18 @@ function copyProperties(source, target) {
 
 // Handle scenarios of:
 // - Inherit from `React.Component` in any fasion
+//   See: https://github.com/FormidableLabs/radium/issues/738
 // - There's an explicit `render` field defined
 function isStateless(component: Function): boolean {
-  return !component.render &&
-    !(component.prototype && component.prototype.render);
+  // This is essentially what babel does for _setting_ prototypes.
+  const proto = Object.getPrototypeOf
+    ? Object.getPrototypeOf(component)
+    : component.__proto_;
+
+  return !(component instanceof Component) &&
+    proto !== Component &&
+    !component.render &&
+    !(component.prototype || {}).render;
 }
 
 // Check if value is a real ES class in Native / Node code.

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -158,9 +158,10 @@ export default function enhanceWithRadium(
       // and rewriting.
       // See: https://github.com/FormidableLabs/radium/issues/738
       RADIUM_METHODS.forEach(name => {
-        const thisDescriptor = Object.getOwnPropertyDescriptor(this, name);
-        const thisMethod = (thisDescriptor || {}).value;
-        const radiumProtoMethod = RADIUM_PROTO[name];
+        const thisDesc = Object.getOwnPropertyDescriptor(this, name);
+        const thisMethod = (thisDesc || {}).value;
+        const radiumDesc = Object.getOwnPropertyDescriptor(RADIUM_PROTO, name)
+        const radiumProtoMethod = radiumDesc.value;
         const superProtoMethod = ComposedComponent.prototype[name];
 
         // Start looking when:
@@ -171,12 +172,10 @@ export default function enhanceWithRadium(
           thisMethod && !superProtoMethod && thisMethod !== radiumProtoMethod
         ) {
           // Transfer dynamic render component to Component prototype (copy).
-          Object.defineProperty(ComposedComponent.prototype, name, {
-            value: thisMethod
-          });
+          Object.defineProperty(ComposedComponent.prototype, name, thisDesc);
 
-          // Recode property descriptor.
-          Object.defineProperty(this, name, {value: radiumProtoMethod});
+          // Recode property descriptor to radium prototype -- doubling up.
+          Object.defineProperty(this, name, radiumDesc);
         }
       });
     }

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {Component} from 'react';
+import {Component, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 
 import StyleKeeper from './style-keeper';
@@ -30,19 +30,14 @@ function copyProperties(source, target) {
 }
 
 // Handle scenarios of:
-// - Inherit from `React.Component` in any fasion
+// - Inherit from `React.Component` in any fashion
 //   See: https://github.com/FormidableLabs/radium/issues/738
 // - There's an explicit `render` field defined
 function isStateless(component: Function): boolean {
-  // This is essentially what babel does for _setting_ prototypes.
-  const proto = Object.getPrototypeOf
-    ? Object.getPrototypeOf(component)
-    : component.__proto_;
+  const proto = component.prototype || {};
 
-  return !(component instanceof Component) &&
-    proto !== Component &&
-    !component.render &&
-    !(component.prototype || {}).render;
+  return !component.isReactComponent && !proto.isReactComponent &&
+    !component.render && !proto.render;
 }
 
 // Check if value is a real ES class in Native / Node code.

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -185,6 +185,10 @@ export default function enhanceWithRadium(
     }
 
     render() {
+      // TODO HERE -- PROBLEM: Radium enhancer `render` not called because
+      // arrow function overwrites in constructor.
+      console.log("super.render", super.render);
+
       const renderedElement = super.render();
       let currentConfig = this.props.radiumConfig ||
         this.context._radiumConfig ||

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -274,7 +274,7 @@ export default function enhanceWithRadium(
 
   // Lazy infer the method names of the Enhancer.
   RADIUM_PROTO = RadiumEnhancer.prototype;
-  RADIUM_METHODS = Object.getOwnPropertyNames(RadiumEnhancer.prototype).filter(
+  RADIUM_METHODS = Object.getOwnPropertyNames(RADIUM_PROTO).filter(
     n => n !== 'constructor' && typeof RADIUM_PROTO[n] === 'function'
   );
 

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -29,6 +29,9 @@ function copyProperties(source, target) {
   });
 }
 
+// Handle scenarios of:
+// - Inherit from `React.Component` in any fasion
+// - There's an explicit `render` field defined
 function isStateless(component: Function): boolean {
   return !component.render &&
     !(component.prototype && component.prototype.render);


### PR DESCRIPTION
- Fixes #738
- This is hacky, but possibly **acceptably** hacky.
- Detect and transfer instance method properties from arrow functions to a copy of the prototype (where by definition they don't exist) to allow property inheritance call chaining by `RadiumEnhancer` which otherwise doesn't get its methods called.

/cc @alexlande @nbrady-techempower @jimsalabim