### PR TITLE
Bug: Render array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Radium Changelog
 
+## Unreleased
+- Fix `render` methods that return array of children. (#950)
+
 ## 0.23.0 (March 15, 2018)
 - Support ES7 arrow functions for React class methods. (#738)
 

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -790,6 +790,37 @@ describe('Radium blackbox tests', () => {
     expect(div.style.color).to.equal('red');
   });
 
+  // Regression test: https://github.com/FormidableLabs/radium/issues/950
+  it.only('works with array children', () => {
+    class TestComponent extends Component {
+      render = () => {
+        return [
+          <div style={{color: 'blue', ':hover': {color: 'red'}}}>
+            {this.props.children}
+          </div>,
+          <div style={{color: 'yellow', ':hover': {color: 'green'}}}>
+            {"two"}
+          </div>
+        ];
+      };
+    }
+
+    const Wrapped = Radium(TestComponent);
+    const output = TestUtils.renderIntoDocument(<Wrapped>hello world</Wrapped>);
+
+    const divs = getElements(output, 'div');
+
+    expect(divs[0].style.color).to.equal('blue');
+    expect(divs[0].innerText).to.equal('hello world');
+    TestUtils.SimulateNative.mouseOver(divs[0]);
+    expect(divs[0].style.color).to.equal('red');
+
+    expect(divs[1].style.color).to.equal('yellow');
+    expect(divs[1].innerText).to.equal('two');
+    TestUtils.SimulateNative.mouseOver(divs[1]);
+    expect(divs[1].style.color).to.equal('green');
+  });
+
   it('works fine if passing null, undefined, or false in style', () => {
     const TestComponent = Radium(() => (
       <div style={{background: undefined, border: false, color: null}} />

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -795,11 +795,11 @@ describe('Radium blackbox tests', () => {
     class TestComponent extends Component {
       render = () => {
         return [
-          <div style={{color: 'blue', ':hover': {color: 'red'}}}>
+          <div key="key0" style={{color: 'blue', ':hover': {color: 'red'}}}>
             {this.props.children}
           </div>,
-          <div style={{color: 'yellow', ':hover': {color: 'green'}}}>
-            {"two"}
+          <div key="key1" style={{color: 'yellow', ':hover': {color: 'green'}}}>
+            two
           </div>
         ];
       };
@@ -811,6 +811,7 @@ describe('Radium blackbox tests', () => {
     const divs = getElements(output, 'div');
 
     expect(divs[0].style.color).to.equal('blue');
+    expect(divs[0].getAttribute('data-radium')).to.equal('true');
     expect(divs[0].innerText).to.equal('hello world');
     TestUtils.SimulateNative.mouseOver(divs[0]);
     expect(divs[0].style.color).to.equal('red');
@@ -864,7 +865,6 @@ describe('Radium blackbox tests', () => {
       </ContextGivingWrapper>
     );
     const div = getElement(output, 'div');
-
     expect(div.style.color).to.equal('blue');
     expect(div.innerText).to.equal('hello world');
 

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -791,7 +791,7 @@ describe('Radium blackbox tests', () => {
   });
 
   // Regression test: https://github.com/FormidableLabs/radium/issues/950
-  it.only('works with array children', () => {
+  it('works with array children', () => {
     class TestComponent extends Component {
       render = () => {
         return [

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -385,6 +385,15 @@ resolveStyles = function(
     );
   }
 
+  // TODO HERE
+  // renderedElement can be an array, not a single element.
+  //
+  // https://github.com/FormidableLabs/radium/issues/950
+  //
+  if (Array.isArray(renderedElement) && !renderedElement.props) {
+    console.log("TODO HERE -- ARRAY WITHOUT PROPS");
+  }
+
   // ReactElement
   if (
     !renderedElement ||
@@ -398,10 +407,6 @@ resolveStyles = function(
     (shouldCheckBeforeResolve && !_shouldResolveStyles(renderedElement))
   ) {
     return {extraStateKeyMap, element: renderedElement};
-  }
-
-  if (!renderedElement.props) {
-    console.log("TODO HERE -- NO PROPS, LIKELY ARRAY");
   }
 
   const children = renderedElement.props.children;

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -388,8 +388,10 @@ resolveStyles = function(
   if (Array.isArray(renderedElement) && !renderedElement.props) {
     const elements = renderedElement.map(element => {
       // element is in-use, so remove from the extraStateKeyMap
-      const key = getStateKey(element);
-      delete extraStateKeyMap[key];
+      if (extraStateKeyMap) {
+        const key = getStateKey(element);
+        delete extraStateKeyMap[key];
+      }
 
       // this element is an array of elements,
       // so return an array of elements with resolved styles

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -391,7 +391,28 @@ resolveStyles = function(
   // https://github.com/FormidableLabs/radium/issues/950
   //
   if (Array.isArray(renderedElement) && !renderedElement.props) {
-    console.log("TODO HERE -- ARRAY WITHOUT PROPS");
+    const elements = renderedElement.map(
+      (element) => {
+        // element is in-use, so remove from the extraStateKeyMap
+        const key = getStateKey(element);
+        delete extraStateKeyMap[key];
+
+        // this element is an array of elements,
+        // so return an array of elements with resolved styles
+        return resolveStyles(
+          component,
+          element,
+          config,
+          existingKeyMap,
+          shouldCheckBeforeResolve,
+          extraStateKeyMap
+        ).element;
+      }
+    );
+    return {
+      extraStateKeyMap,
+      element: elements
+    };
   }
 
   // ReactElement

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -385,11 +385,6 @@ resolveStyles = function(
     );
   }
 
-  // TODO HERE
-  // renderedElement can be an array, not a single element.
-  //
-  // https://github.com/FormidableLabs/radium/issues/950
-  //
   if (Array.isArray(renderedElement) && !renderedElement.props) {
     const elements = renderedElement.map(element => {
       // element is in-use, so remove from the extraStateKeyMap

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -391,24 +391,22 @@ resolveStyles = function(
   // https://github.com/FormidableLabs/radium/issues/950
   //
   if (Array.isArray(renderedElement) && !renderedElement.props) {
-    const elements = renderedElement.map(
-      (element) => {
-        // element is in-use, so remove from the extraStateKeyMap
-        const key = getStateKey(element);
-        delete extraStateKeyMap[key];
+    const elements = renderedElement.map(element => {
+      // element is in-use, so remove from the extraStateKeyMap
+      const key = getStateKey(element);
+      delete extraStateKeyMap[key];
 
-        // this element is an array of elements,
-        // so return an array of elements with resolved styles
-        return resolveStyles(
-          component,
-          element,
-          config,
-          existingKeyMap,
-          shouldCheckBeforeResolve,
-          extraStateKeyMap
-        ).element;
-      }
-    );
+      // this element is an array of elements,
+      // so return an array of elements with resolved styles
+      return resolveStyles(
+        component,
+        element,
+        config,
+        existingKeyMap,
+        shouldCheckBeforeResolve,
+        extraStateKeyMap
+      ).element;
+    });
     return {
       extraStateKeyMap,
       element: elements
@@ -459,10 +457,7 @@ resolveStyles = function(
   // If nothing changed, don't bother cloning the element. Might be a bit
   // wasteful, as we add the sentinel to stop double-processing when we clone.
   // Assume benign double-processing is better than unneeded cloning.
-  if (
-    newChildren === children &&
-    newProps === renderedElement.props
-  ) {
+  if (newChildren === children && newProps === renderedElement.props) {
     return {extraStateKeyMap, element: renderedElement};
   }
 

--- a/src/resolve-styles.js
+++ b/src/resolve-styles.js
@@ -400,8 +400,14 @@ resolveStyles = function(
     return {extraStateKeyMap, element: renderedElement};
   }
 
+  if (!renderedElement.props) {
+    console.log("TODO HERE -- NO PROPS, LIKELY ARRAY");
+  }
+
+  const children = renderedElement.props.children;
+
   const newChildren = _resolveChildren({
-    children: renderedElement.props.children,
+    children,
     component,
     config,
     existingKeyMap,
@@ -425,10 +431,10 @@ resolveStyles = function(
   });
 
   // If nothing changed, don't bother cloning the element. Might be a bit
-  // wasteful, as we add the sentinal to stop double-processing when we clone.
+  // wasteful, as we add the sentinel to stop double-processing when we clone.
   // Assume benign double-processing is better than unneeded cloning.
   if (
-    newChildren === renderedElement.props.children &&
+    newChildren === children &&
     newProps === renderedElement.props
   ) {
     return {extraStateKeyMap, element: renderedElement};

--- a/test/radium-test.js
+++ b/test/radium-test.js
@@ -128,7 +128,7 @@ describe('Radium blackbox SSR tests', () => {
   describe('render scenarios', () => {
 
     // Regression test: https://github.com/FormidableLabs/radium/issues/950
-    it.only('handles rendered child array', () => {
+    it('handles rendered child array', () => {
       class Composed extends React.Component {
         render() {
           return [

--- a/test/radium-test.js
+++ b/test/radium-test.js
@@ -124,4 +124,33 @@ describe('Radium blackbox SSR tests', () => {
       );
     });
   });
+
+  describe('render scenarios', () => {
+
+    // Regression test: https://github.com/FormidableLabs/radium/issues/950
+    it.only('handles rendered child array', () => {
+      class Composed extends React.Component {
+        render() {
+          return [
+            React.createElement('div', {
+              style: {
+                color: 'blue'
+              }
+            }),
+            React.createElement('div', {
+              style: {
+                color: 'red'
+              }
+            })
+          ];
+        }
+      }
+
+      const rendered = render(Radium(Composed));
+      expect(rendered).to.contain(
+        '<div style="color:blue" data-radium="true"></div>' +
+        '<div style="color:red" data-radium="true"></div>'
+      );
+    });
+  });
 });

--- a/test/radium-test.js
+++ b/test/radium-test.js
@@ -126,7 +126,6 @@ describe('Radium blackbox SSR tests', () => {
   });
 
   describe('render scenarios', () => {
-
     // Regression test: https://github.com/FormidableLabs/radium/issues/950
     it('handles rendered child array', () => {
       class Composed extends React.Component {
@@ -151,7 +150,7 @@ describe('Radium blackbox SSR tests', () => {
       const rendered = render(Radium(Composed));
       expect(rendered).to.contain(
         '<div style="color:blue" data-radium="true"></div>' +
-        '<div style="color:red" data-radium="true"></div>'
+          '<div style="color:red" data-radium="true"></div>'
       );
     });
   });

--- a/test/radium-test.js
+++ b/test/radium-test.js
@@ -133,11 +133,13 @@ describe('Radium blackbox SSR tests', () => {
         render() {
           return [
             React.createElement('div', {
+              key: 0,
               style: {
                 color: 'blue'
               }
             }),
             React.createElement('div', {
+              key: 1,
               style: {
                 color: 'red'
               }


### PR DESCRIPTION
React 16 introduced [rendering arrays of elements](https://reactjs.org/blog/2017/09/26/react-v16.0.html).

```jsx
render() {
  return [
    <li key="A">First item</li>,
    <li key="B">Second item</li>,
    <li key="C">Third item</li>,
  ];
}
```

This usage threw an error in Radium: https://github.com/FormidableLabs/radium/issues/950