### PR TITLE
Test React Fragments (React 16.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,9 +102,9 @@
     "nodemon": "^1.11.0",
     "object-assign": "^4.1.1",
     "prettier": "^0.22.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-test-renderer": "^16.0.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "react-test-renderer": "^16.2.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
     "webpack-dev-server": "^2.11.1"

--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -822,6 +822,42 @@ describe('Radium blackbox tests', () => {
     expect(divs[1].style.color).to.equal('green');
   });
 
+  it('works with Fragments', () => {
+    class TestComponent extends Component {
+      render = () => {
+        return (
+          <React.Fragment>
+            <div key="key0" style={{color: 'blue', ':hover': {color: 'red'}}}>
+              {this.props.children}
+            </div>
+            <div
+              key="key1"
+              style={{color: 'yellow', ':hover': {color: 'green'}}}
+            >
+              two
+            </div>
+          </React.Fragment>
+        );
+      };
+    }
+
+    const Wrapped = Radium(TestComponent);
+    const output = TestUtils.renderIntoDocument(<Wrapped>hello world</Wrapped>);
+
+    const divs = getElements(output, 'div');
+
+    expect(divs[0].style.color).to.equal('blue');
+    expect(divs[0].getAttribute('data-radium')).to.equal('true');
+    expect(divs[0].innerText).to.equal('hello world');
+    TestUtils.SimulateNative.mouseOver(divs[0]);
+    expect(divs[0].style.color).to.equal('red');
+
+    expect(divs[1].style.color).to.equal('yellow');
+    expect(divs[1].innerText).to.equal('two');
+    TestUtils.SimulateNative.mouseOver(divs[1]);
+    expect(divs[1].style.color).to.equal('green');
+  });
+
   it('works fine if passing null, undefined, or false in style', () => {
     const TestComponent = Radium(() => (
       <div style={{background: undefined, border: false, color: null}} />

--- a/test/radium-test.js
+++ b/test/radium-test.js
@@ -153,5 +153,34 @@ describe('Radium blackbox SSR tests', () => {
           '<div style="color:red" data-radium="true"></div>'
       );
     });
+
+    it('handles rendered Fragments', () => {
+      class Composed extends React.Component {
+        render() {
+          return React.createElement(React.Fragment, {
+            children: [
+              React.createElement('div', {
+                key: 0,
+                style: {
+                  color: 'blue'
+                }
+              }),
+              React.createElement('div', {
+                key: 1,
+                style: {
+                  color: 'red'
+                }
+              })
+            ]
+          });
+        }
+      }
+
+      const rendered = render(Radium(Composed));
+      expect(rendered).to.contain(
+        '<div style="color:blue" data-radium="true"></div>' +
+          '<div style="color:red" data-radium="true"></div>'
+      );
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5942,25 +5942,26 @@ rc@^1.0.1, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+react-dom@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-test-renderer@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
+react-test-renderer@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
-react@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+react@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Tests for React Fragments, which were part of `react@16.2.0`. 

By necessity this upgrades our dev deps to `react@16.2.0` (and `react-dom` and `react-test-renderer`) 

Note that _Radium_ (not React) requires keys on children, even if they are in a Fragment. This was also the case with normal children of a parent element, like a `div`.