### PR TITLE
Fix animation race condition on Safari

### DIFF
--- a/src/components/style-sheet.js
+++ b/src/components/style-sheet.js
@@ -22,7 +22,7 @@ export default class StyleSheet extends PureComponent<{}, {css: string}> {
     this._subscription = this.context._radiumStyleKeeper.subscribe(
       this._onChange
     );
-    this._onChange();
+    setTimeout(this._onChange, 0);
   }
 
   componentWillUnmount() {
@@ -40,12 +40,9 @@ export default class StyleSheet extends PureComponent<{}, {css: string}> {
   }
 
   _onChange = () => {
-    setTimeout(
-      () => {
-        this._isMounted && this.setState(this._getCSSState());
-      },
-      0
-    );
+    if (this._isMounted) {
+      this.setState(this._getCSSState());
+    }
   };
 
   render(): Node {


### PR DESCRIPTION
Fixes #192 :

On Safari, there is a race condition, in which the `@keyframes` are added to the `<StyleSheet>` on the page after the `animationName` style property is added to the styled element. Safari doesn't find the animation, and doesn't refresh those elements when the animation is added to the stylesheet.

Looking at the code, the update of the global stylesheet (`src/components/style-sheet.js:43`) is deferred by 0 milliseconds, while the addition of the style rule to the element is synchronous. This would cause the race condition described above.

This PR removes the debouncing from the CSS change listener, but leaves the debounce in `componentDidMount` intact.