### PR TITLE
Fix console warnings when running examples.

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -293,7 +293,7 @@ const listStyle = {
   marginTop: 15,
   marginBottom: 15,
   marginLeft: 15,
-  marginRight: 15,
+  marginRight: 15
 };
 
 export default App;

--- a/examples/app.js
+++ b/examples/app.js
@@ -290,7 +290,10 @@ const multiAnimationStyles = {
 const listStyle = {
   ...resetListStyle,
   ...resetBoxModel,
-  margin: 15
+  marginTop: 15,
+  marginBottom: 15,
+  marginLeft: 15,
+  marginRight: 15,
 };
 
 export default App;


### PR DESCRIPTION
Removes console warning due to mixed use of margin shorthand with specific marginX properties.