### PR TITLE
Fix media query ordering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -151,7 +151,7 @@ rules:
     no-undefined: 0                # disallow use of undefined variable
     no-unused-vars: 2              # disallow declaration of variables that are not used in
                                    #    the code
-    no-use-before-define: 2        # disallow use of variables before they are defined
+    no-use-before-define: 1        # disallow use of variables before they are defined
     no-var: 2
 
     ###########################################################################

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@ ecmaFeatures:
 plugins: ["react", "flow-vars", "prettier"]
 
 env:
+    es6: true
     browser: true
     node: true
     amd: false

--- a/src/plugins/resolve-media-queries-plugin.js
+++ b/src/plugins/resolve-media-queries-plugin.js
@@ -45,7 +45,7 @@ const getStyleID = style => {
     styleIDMap.set(key, `${++styleIndex}`);
   }
 
-  return styleIDMap.get(key);
+  return styleIDMap.get(key) || '';
 };
 
 function _topLevelRulesToCSS({

--- a/src/plugins/resolve-media-queries-plugin.js
+++ b/src/plugins/resolve-media-queries-plugin.js
@@ -37,7 +37,7 @@ function _removeMediaQueries(style) {
   }, {});
 }
 
-const styleIDMap = new Map();
+const styleIDMap = new WeakMap();
 let styleIndex = 0;
 const getStyleID = style => {
   const key = style;

--- a/src/plugins/resolve-media-queries-plugin.js
+++ b/src/plugins/resolve-media-queries-plugin.js
@@ -116,7 +116,6 @@ function _subscribeToMediaQuery({
 }
 
 export default function resolveMediaQueries({
-  styleID,
   ExecutionEnvironment,
   addCSS,
   appendImportantToEachValue,


### PR DESCRIPTION
Fixes #975 

Identical media queries with identical rulesets across different components were being deduped which
broke user-defined media query ordering.