### PR TITLE
Update unitless CSS property list and licensing.

### DIFF
--- a/src/append-px-if-needed.js
+++ b/src/append-px-if-needed.js
@@ -1,22 +1,33 @@
 /* @flow */
 
 // Copied from https://github.com/facebook/react/blob/
-// 102cd291899f9942a76c40a0e78920a6fe544dc1/
-// src/renderers/dom/shared/CSSProperty.js
+// b87aabdfe1b7461e7331abb3601d9e6bb27544bc/
+// packages/react-dom/src/shared/CSSProperty.js
 const isUnitlessNumber = {
   animationIterationCount: true,
+  borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
   boxFlex: true,
   boxFlexGroup: true,
   boxOrdinalGroup: true,
   columnCount: true,
+  columns: true,
   flex: true,
   flexGrow: true,
   flexPositive: true,
   flexShrink: true,
   flexNegative: true,
   flexOrder: true,
+  gridArea: true,
   gridRow: true,
+  gridRowEnd: true,
+  gridRowSpan: true,
+  gridRowStart: true,
   gridColumn: true,
+  gridColumnEnd: true,
+  gridColumnSpan: true,
+  gridColumnStart: true,
   fontWeight: true,
   lineClamp: true,
   lineHeight: true,
@@ -30,8 +41,11 @@ const isUnitlessNumber = {
 
   // SVG-related properties
   fillOpacity: true,
+  floodOpacity: true,
   stopOpacity: true,
+  strokeDasharray: true,
   strokeDashoffset: true,
+  strokeMiterlimit: true,
   strokeOpacity: true,
   strokeWidth: true
 };


### PR DESCRIPTION
This commit solves two issues in append-px-if-needed:

1. The list of properties is out of date for unitless CSS properties.
2. Updates the licensing for this copied code snippet to the more friendly MIT license.