### PR TITLE
Add maintenance status to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Radium is a set of tools to manage inline styles on React elements. It gives you
 _Inspired by_ <a href="https://speakerdeck.com/vjeux/react-css-in-js">React: CSS in JS</a>
 by <a href="https://twitter.com/Vjeux">vjeux</a>.
 
+### Maintenance Status: Stable
+
+Formidable is not planning to develop any new features for this project. We are still responding to bug reports and security concerns. We are still welcoming PRs for this project, but PRs that include new features should be small and easy to integrate and should not include breaking changes.
+
 ## Overview
 
 Eliminating CSS in favor of inline styles that are computed on the fly is a powerful approach, providing a number of benefits over traditional CSS:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![NPM Package][npm_img]][npm_site]
 [![Dependency Status][david_img]][david_site]
 ![gzipped size][size_img]
+[![Maintenance Status][maintenance-image]](#maintenance-status)
+
 
 # Radium
 
@@ -15,10 +17,6 @@ Radium is a set of tools to manage inline styles on React elements. It gives you
 
 _Inspired by_ <a href="https://speakerdeck.com/vjeux/react-css-in-js">React: CSS in JS</a>
 by <a href="https://twitter.com/Vjeux">vjeux</a>.
-
-### Maintenance Status: Stable
-
-Formidable is not planning to develop any new features for this project. We are still responding to bug reports and security concerns. We are still welcoming PRs for this project, but PRs that include new features should be small and easy to integrate and should not include breaking changes.
 
 ## Overview
 
@@ -186,6 +184,11 @@ You can find a list of other tools, components, and frameworks to help you build
 
 Please see [CONTRIBUTING](https://github.com/FormidableLabs/radium/blob/master/CONTRIBUTING.md)
 
+## Maintenance Status
+
+**Stable:** Formidable is not planning to develop any new features for this project. We are still responding to bug reports and security concerns. We are still welcoming PRs for this project, but PRs that include new features should be small and easy to integrate and should not include breaking changes.
+
+
 [trav_img]: https://api.travis-ci.org/FormidableLabs/radium.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/radium
 [cov_img]: https://img.shields.io/coveralls/FormidableLabs/radium.svg
@@ -200,3 +203,4 @@ Please see [CONTRIBUTING](https://github.com/FormidableLabs/radium/blob/master/C
 [docs_faq]: https://github.com/FormidableLabs/radium/tree/master/docs/faq
 [appveyor_img]: https://ci.appveyor.com/api/projects/status/github/formidablelabs/radium?branch=master&svg=true
 [appveyor_site]: https://ci.appveyor.com/project/ryan-roemer/radium
+[maintenance-image]: https://img.shields.io/badge/maintenance-stable-blue.svg


### PR DESCRIPTION
@kylecesmat This PR adds a maintenance status note to the readme. I think it might make sense to delay merging this until the blog post about Radium is published. I would also love if this could coincide with the addition of a section in the readme about alternatives to Radium.