### PR TITLE
Fix initial enhancer state for fn components

### DIFF
--- a/src/__tests__/enhancer-test.js
+++ b/src/__tests__/enhancer-test.js
@@ -21,6 +21,24 @@ describe('Enhancer', () => {
     expect(ref.current.state).to.deep.equal({_radiumStyleState: {}});
   });
 
+  it('sets up initial state on a function component', () => {
+    // using plugin API to get state as state hooks keep things pretty private
+    // so we cannot just dive into the component instance like with the class example
+    const dummyPlugin = sinon.spy();
+    const Composed = props => <div {...props} />;
+    const Enhanced = Enhancer(Composed, {
+      plugins: [dummyPlugin]
+    });
+
+    renderFcIntoDocument(<Enhanced style={{color: 'red'}} />);
+
+    const pluginApi = dummyPlugin.getCall(0).args[0];
+
+    expect(pluginApi.getComponentField('state')).to.deep.equal({
+      _radiumStyleState: {}
+    });
+  });
+
   it('merges with existing state', () => {
     class Composed extends Component {
       constructor(props) {

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -178,7 +178,7 @@ function createEnhancedFunctionComponent(
     const {radiumConfig, ...otherProps} = props;
     const radiumConfigContext = useContext(RadiumConfigContext);
     const styleKeeperContext = useContext(StyleKeeperContext);
-    const [state, setState] = useState({});
+    const [state, setState] = useState({_radiumStyleState: {}});
 
     const enhancerApi = useRef<EnhancerApi>({
       state,


### PR DESCRIPTION
This addresses https://github.com/FormidableLabs/radium/issues/1034

The listener in the plugin where the error is being raised will run and if `_radiumStyleState: {}` hasn't been set by another action yet we have issues. There is a test enforcing this initial state for class components and I have added one for function components and fixed the issue.

cc @dancherb